### PR TITLE
Fix a bug in the getHarmony method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.6] - 2021-03-20
+
+- Fix a bug in the getHarmony method when the input is a hex object without alpha
+- Refactor the code to remove unused lines
+- Improved the test coverage
+
 ## [1.3.5] - 2020-12-17
 
 - Updated packages, solved vulnerabilities

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://elchininet.github.io/ColorTranslator/">
-        <img src="./src/@demo/images/logo.png?raw=true" width="500" title="ColorTranslator" />
+        <img src="https://raw.githubusercontent.com/elchininet/ColorTranslator/master/src/%40demo/images/logo.png" width="500" title="ColorTranslator" />
     </a>
     <br>
     A JavaScript library, written in TypeScript, to convert among different color models

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -50,8 +50,10 @@ export interface CMYKObjectGeneric {
 }
 
 export type Color = RGBObjectGeneric | HSLObjectGeneric | CMYKObjectGeneric;
+export type ColorWithoutCMYK = RGBObjectGeneric | HSLObjectGeneric;
 
 export type ColorInput = string | Color;
+export type ColorInputWithoutCMYK = string | ColorWithoutCMYK;
 export type HEXOutput = string | HEXObject;
 export type RGBOutput = string | RGBObject;
 export type HSLOutput = string | HSLObject;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {
     Color,
     ColorInput,
+    ColorInputWithoutCMYK,
     HSLObjectGeneric,
     HEXObject,
     RGBObject,
@@ -16,7 +17,7 @@ import { ColorModel, Harmony } from '#constants';
 import { rgbToHSL, hslToRGB, rgbToCMYK, cmykToRGB } from '#color/translators';
 import * as utils from '#color/utils';
 import { CSS } from '#color/css';
-import { hasProp, round, minmax } from '#helpers';
+import { round, minmax } from '#helpers';
 
 const check = (color: ColorInput, css: boolean): boolean => (typeof color === 'string' && css || typeof color === 'object' && !css);
 
@@ -224,40 +225,41 @@ export class ColorTranslator {
     }
 
     public get RGBObject(): RGBObject {
-        const rgb = { ...this.rgb };
-        return utils.translateColor.RGB(rgb);
+        return {
+            r: this.R,
+            g: this.G,
+            b: this.B
+        };
     }
 
     public get RGBAObject(): RGBObject {
-        const rgb = { ...this.rgb };
-        return utils.translateColor.RGBA(rgb);
+        return {
+            ...this.RGBObject,
+            a: this.A
+        };
     }
 
     public get HSLObject(): HSLObject {
         return {
-            h: round(this.hsl.h),
-            s: round(this.hsl.s),
-            l: round(this.hsl.l)
+            h: this.H,
+            s: this.S,
+            l: this.L
         };
     }
 
     public get HSLAObject(): HSLObject {
         return {
-            h: round(this.hsl.h),
-            s: round(this.hsl.s),
-            l: round(this.hsl.l),
-            a: hasProp<HSLObject>(this.hsl, 'a')
-                ? round(this.hsl.a, 2)
-                : 1
+            ...this.HSLObject,
+            a: this.A
         };
     }
 
     public get CMYKObject(): CMYKObject {
         return {
-            c: round(this.cmyk.c),
-            m: round(this.cmyk.m),
-            y: round(this.cmyk.y),
-            k: round(this.cmyk.k)
+            c: this.C,
+            m: this.M,
+            y: this.Y,
+            k: this.K
         };
     }
 
@@ -269,8 +271,8 @@ export class ColorTranslator {
     }
 
     public get HEXA(): string {
-        const { r, g, b, a = 1 } = this.rgb;
-        const rgb = { r, g, b, a: a * 255 };
+        const { r, g, b } = this.rgb;
+        const rgb = { r, g, b, a: this.A * 255 };
         return CSS.HEX(rgb);
     }
 
@@ -281,8 +283,8 @@ export class ColorTranslator {
     }
 
     public get RGBA(): string {
-        const { r, g, b, a = 1 } = this.rgb;
-        const rgb = { r, g, b, a };
+        const { r, g, b } = this.rgb;
+        const rgb = { r, g, b, a: this.A };
         return CSS.RGB(rgb);
     }
 
@@ -293,9 +295,7 @@ export class ColorTranslator {
     }
 
     public get HSLA(): string {
-        const { h, s, l, a = 1 } = this.hsl;
-        const hsl = { h, s, l, a };
-        return CSS.HSL(hsl);
+        return CSS.HSL(this.hsl);
     }
 
     public get CMYK(): string {
@@ -417,7 +417,7 @@ export class ColorTranslator {
     public static getHarmony(color: RGBObject, armony?: Harmony): RGBObject[];
     public static getHarmony(color: HSLObjectGeneric, armony?: Harmony): HSLObject[];
     public static getHarmony<T>(color: string, armony?: Harmony): T[];
-    public static getHarmony(color: ColorInput, armony: Harmony = Harmony.COMPLEMENTARY): ColorOutput[] {
+    public static getHarmony(color: ColorInputWithoutCMYK, armony: Harmony = Harmony.COMPLEMENTARY): ColorOutput[] {
         switch(armony) {
             case Harmony.ANALOGOUS:
                 return utils.colorHarmony.buildHarmony(color, utils.analogous);

--- a/tests/blending.test.ts
+++ b/tests/blending.test.ts
@@ -8,28 +8,33 @@ describe('ColorTranslator blending tests', (): void => {
         const to = '#0000FF';
 
         const blendFunctions = [
-            { colorFn: ColorTranslator.toHEX, blendFn: ColorTranslator.getBlendHEX },
+            { colorFn: ColorTranslator.toHEX,  blendFn: ColorTranslator.getBlendHEX  },
             { colorFn: ColorTranslator.toHEXA, blendFn: ColorTranslator.getBlendHEXA },
-            { colorFn: ColorTranslator.toRGB, blendFn: ColorTranslator.getBlendRGB },
+            { colorFn: ColorTranslator.toRGB,  blendFn: ColorTranslator.getBlendRGB  },
             { colorFn: ColorTranslator.toRGBA, blendFn: ColorTranslator.getBlendRGBA },
-            { colorFn: ColorTranslator.toHSL, blendFn: ColorTranslator.getBlendHSL },
+            { colorFn: ColorTranslator.toHSL,  blendFn: ColorTranslator.getBlendHSL  },
             { colorFn: ColorTranslator.toHSLA, blendFn: ColorTranslator.getBlendHSLA }
         ];
 
         const result1 = [ '#FF0000', '#800080', '#0000FF' ];
         const result2 = [ '#FF0000', '#CC0033', '#990066', '#660099', '#3300CC', '#0000FF' ];
+        const result3 = [ '#FF0000', '#BF0040', '#800080', '#4000BF', '#0000FF' ];
 
         blendFunctions.forEach((obj): void => {
 
             const r1 = result1.map(c => obj.colorFn(c));
             const r2 = result2.map(c => obj.colorFn(c));
-            const r3 = result1.map(c => obj.colorFn(c, false));
-            const r4 = result2.map(c => obj.colorFn(c, false));
+            const r3 = result3.map(c => obj.colorFn(c));
+            const r4 = result1.map(c => obj.colorFn(c, false));
+            const r5 = result2.map(c => obj.colorFn(c, false));
+            const r6 = result3.map(c => obj.colorFn(c, false));
 
             expect(obj.blendFn(from, to, r1.length)).toMatchObject(r1);
             expect(obj.blendFn(from, to, r2.length)).toMatchObject(r2);
-            expect(obj.blendFn(from, to, r1.length, false)).toMatchObject(r3);
-            expect(obj.blendFn(from, to, r2.length, false)).toMatchObject(r4);
+            expect(obj.blendFn(from, to)).toMatchObject(r3);
+            expect(obj.blendFn(from, to, r1.length, false)).toMatchObject(r4);
+            expect(obj.blendFn(from, to, r2.length, false)).toMatchObject(r5);
+            expect(obj.blendFn(from, to, undefined, false)).toMatchObject(r6);
 
         });
         

--- a/tests/data/data.ts
+++ b/tests/data/data.ts
@@ -333,4 +333,3 @@ export const CLASS_PROPERTIES = {
 };
 
 export const ColorTranslator = ct;
-export { Harmony };

--- a/tests/harmony.test.ts
+++ b/tests/harmony.test.ts
@@ -1,4 +1,6 @@
-import { ColorTranslator, Harmony } from './data/data';
+import { ColorTranslator } from './data/data';
+import { Harmony } from '../src/constants';
+import { HEXObject, RGBObject, HSLObjectGeneric } from '../src/@types';
 
 describe('ColorTranslator harmony tests', (): void => {    
 
@@ -26,15 +28,24 @@ describe('ColorTranslator harmony tests', (): void => {
 
         colorFunctions.forEach((fn): void => {
 
-            const b = fn(base);
-            const r = results.map(colors => colors.map(color => fn(color)));
+            const css = fn(base);
+            const obj = fn(base, false) as HEXObject & RGBObject & HSLObjectGeneric;
+            const resultCSS = results.map(colors => colors.map(color => fn(color)));
+            const resultObject = results.map(colors => colors.map(color => fn(color, false))) as (HEXObject | RGBObject | HSLObjectGeneric)[][];
 
-            it(`Harmony deep equals: ${harmony} for ${b} => ${JSON.stringify(r[index])}`, (): void => {
-
-                const colors = ColorTranslator.getHarmony(b, Harmony[harmony as Harmony]);
-                expect(colors).toMatchObject(r[index]);
-
-            });            
+            it(`Harmony deep equals: ${harmony} for ${css} => ${JSON.stringify(resultCSS[index])}`, (): void => {
+                const colors = harmony === Harmony.COMPLEMENTARY
+                    ? ColorTranslator.getHarmony(css)
+                    : ColorTranslator.getHarmony(css, Harmony[harmony as Harmony]);
+                expect(colors).toMatchObject(resultCSS[index]);
+            });
+            
+            it(`Harmony deep equals: ${harmony} for ${JSON.stringify(obj)} => ${JSON.stringify(resultObject[index])}`, (): void => {
+                const colors = harmony === Harmony.COMPLEMENTARY
+                    ? ColorTranslator.getHarmony(obj)
+                    : ColorTranslator.getHarmony(obj, Harmony[harmony as Harmony]);
+                expect(colors).toMatchObject(resultObject[index]);
+            });
 
         });  
 

--- a/tests/hex3.test.ts
+++ b/tests/hex3.test.ts
@@ -1,11 +1,14 @@
-import { HEX3, ColorProps, ColorTranslator } from './data/data';
+import { HEX3, ColorTranslator } from './data/data';
 
-const hex3Props = ['hex', 'hexObject', 'hexa', 'hexaObject', 'hexObjectPercent', 'rgbPercent'];
+type HexProps = typeof HEX3[0];
+type Props = keyof HexProps;
 
-HEX3.forEach((item: ColorProps): void => {
+const hex3Props: Props[] = ['hex', 'hexObject', 'hexa', 'hexaObject', 'hexObjectPercent', 'rgbPercent'];
+
+HEX3.forEach((item: HexProps): void => {
 
     // Iterate over the color models
-    hex3Props.forEach((prop: keyof ColorProps): void => {
+    hex3Props.forEach((prop: Props): void => {
 
         describe(`ColorTranslator dynamic test for the HEX3 color: ${JSON.stringify(item[prop])}`, (): void => {
 

--- a/tests/hsl-objects.test.ts
+++ b/tests/hsl-objects.test.ts
@@ -1,8 +1,10 @@
 import { COLORS, FUNCTIONS, ColorProps } from './data/data';
 import { HSLObject } from '../src/@types';
 
+type Props = keyof typeof COLORS[0];
+
 // Test HSL Objects
-const hslTo = ['rgb', 'rgbObject', 'rgba', 'rgbaObject', 'hex', 'hexObject', 'hexa', 'hexaObject'];
+const hslTo: Props[] = ['rgb', 'rgbObject', 'rgba', 'rgbaObject', 'hex', 'hexObject', 'hexa', 'hexaObject'];
 
 COLORS.forEach((item: ColorProps): void => {
 
@@ -17,7 +19,7 @@ COLORS.forEach((item: ColorProps): void => {
         const hslLowHue = { ...hsl, h: hsl.h - 360 };
         const hslaLowHue = { ...hsl, h: hsl.h - 360 };
 
-        hslTo.forEach((prop: keyof ColorProps): void => {
+        hslTo.forEach((prop: Props): void => {
 
             const functionCall = FUNCTIONS[prop].func;
             const cssProps = FUNCTIONS[prop].css;

--- a/tests/static-methods.test.ts
+++ b/tests/static-methods.test.ts
@@ -1,12 +1,14 @@
-import { COLORS, FUNCTIONS, ColorProps } from './data/data';
+import { COLORS, FUNCTIONS, ColorProps, ColorTranslator } from './data/data';
+
+type Props = keyof typeof COLORS[0];
 
 //Iterate over the colors
 COLORS.forEach((item: ColorProps): void => {
 
-    const colors = Object.keys(item);
+    const colors = Object.keys(item) as Props[];
 
     // Iterate over the color models
-    colors.forEach((color1: keyof ColorProps): void => {
+    colors.forEach((color1: Props): void => {
 
         describe(`ColorTranslator dynamic tests from ${color1}: ${JSON.stringify(item[color1])}`, (): void => {
 
@@ -14,7 +16,7 @@ COLORS.forEach((item: ColorProps): void => {
             const convertString = typeof convert === 'string' ? convert : JSON.stringify(convert);
 
             // Iterate again the color models
-            colors.forEach((color2: keyof ColorProps): void => {
+            colors.forEach((color2: Props): void => {
 
                 const functionName = FUNCTIONS[color2].name;
                 const functionCall = FUNCTIONS[color2].func;


### PR DESCRIPTION
The getHarmony method was returning hex objects with alpha when the input provided was a hex object without alpha.