### PR TITLE
Fix rounding values of hexadecimal colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## [1.10.2] - 2023-01-17
+
+- Fixed rounded values of hexadecimal colors
+
 ## [1.10.1] - 2023-01-10
 
-- Fix RYB to RGB conversion (thanks to @jagracar)
+- Fixed RYB to RGB conversion (thanks to @jagracar)
 
 ## [1.10.0] - 2023-01-05
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import pkg from './package.json';
 import ts from 'rollup-plugin-ts';
-import { terser } from "rollup-plugin-terser";
+import { terser } from 'rollup-plugin-terser';
 
 export default {
     plugins: [

--- a/src/color/css.ts
+++ b/src/color/css.ts
@@ -1,10 +1,19 @@
-import { ColorModel } from '#constants';
-import { HEXObject, RGBObject, HSLObject, CMYKObject } from '@types';
-import { toHEX, hasProp, round } from '#helpers';
+import { ColorModel, MIN_DECIMALS } from '#constants';
+import {
+    HEXObject,
+    RGBObject,
+    HSLObject,
+    CMYKObject
+} from '@types';
+import {
+    toHEX,
+    hasProp,
+    round
+} from '#helpers';
 
 export const CSS = {
     [ColorModel.HEX]: (color: HEXObject | RGBObject): string => `#${toHEX(color.r)}${toHEX(color.g)}${toHEX(color.b)}${hasProp(color, 'a') && toHEX(color.a) || ''}`,
-    [ColorModel.RGB]: (color: RGBObject): string => `rgb${hasProp<RGBObject>(color, 'a') && 'a' || ''}(${round(color.r)},${round(color.g)},${round(color.b)}${hasProp<RGBObject>(color, 'a') && `,${round(color.a, 2)}` || ''})`,
-    [ColorModel.HSL]: (color: HSLObject): string => `hsl${hasProp<HSLObject>(color, 'a') && 'a' || ''}(${round(color.h)},${round(color.s)}%,${round(color.l)}%${hasProp<HSLObject>(color, 'a') && `,${round(color.a, 2)}` || ''})`,
-    [ColorModel.CMYK]: (color: CMYKObject): string => `cmyk(${round(color.c)}%,${round(color.m)}%,${round(color.y)}%,${round(color.k)}%${hasProp<CMYKObject>(color, 'a') && `,${round(color.a,2)}` || ''})`
+    [ColorModel.RGB]: (color: RGBObject): string => `rgb${hasProp<RGBObject>(color, 'a') && 'a' || ''}(${round(color.r)},${round(color.g)},${round(color.b)}${hasProp<RGBObject>(color, 'a') && `,${round(color.a, MIN_DECIMALS)}` || ''})`,
+    [ColorModel.HSL]: (color: HSLObject): string => `hsl${hasProp<HSLObject>(color, 'a') && 'a' || ''}(${round(color.h)},${round(color.s)}%,${round(color.l)}%${hasProp<HSLObject>(color, 'a') && `,${round(color.a, MIN_DECIMALS)}` || ''})`,
+    [ColorModel.CMYK]: (color: CMYKObject): string => `cmyk(${round(color.c)}%,${round(color.m)}%,${round(color.y)}%,${round(color.k)}%${hasProp<CMYKObject>(color, 'a') && `,${round(color.a, MIN_DECIMALS)}` || ''})`
 };

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -25,7 +25,8 @@ import {
     COLORREGS,
     COLOR_KEYS,
     ERRORS,
-    HSL_HUE
+    HSL_HUE,
+    MAX_DECIMALS
 } from '#constants';
 import {
     getOrderedArrayString,
@@ -92,7 +93,7 @@ export const normalizeAlpha = (alpha: number | string | undefined | null): numbe
             alpha = +alpha;
         }
     }
-    return (isNaN(+alpha) || alpha > 1) ? 1 : round(alpha, 2);
+    return (isNaN(+alpha) || alpha > 1) ? 1 : round(alpha, MAX_DECIMALS);
 };
 
 //---Harmony
@@ -411,7 +412,7 @@ export const getColorMixture = (color: ColorInputWithoutCMYK, steps: number, sha
                     if (hasAlpha) rgbColor.a = hslColor.a;
                     return isCSS
                         ? hasAlpha
-                            ? CSS.HEX({ ...rgbColor, a: round(rgbColor.a * 255, 2) })
+                            ? CSS.HEX({ ...rgbColor, a: round(rgbColor.a * 255, MAX_DECIMALS) })
                             : CSS.HEX(rgbColor)
                         : hasAlpha
                             ? translateColor.HEXA(rgbColor)

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './numbers';
 export * from './enums';
 export * from './regexps';
 export * from './errors';

--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -1,0 +1,2 @@
+export const MAX_DECIMALS = 6;
+export const MIN_DECIMALS = 2;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,5 +1,5 @@
 import { NumberOrString } from '@types';
-import { PCENT, HEX } from '#constants';
+import { PCENT, HEX, MAX_DECIMALS } from '#constants';
 
 //---Has property
 export const hasProp = <T>(obj: T, prop: string): boolean => Object.prototype.hasOwnProperty.call(obj, prop);
@@ -17,14 +17,14 @@ export const getDEC = (hex: string): number => {
 
 //---Convert to hexadecimal
 export const getHEX = (number: NumberOrString): string => {
-    const hex = parseInt(`${number}`).toString(16).toUpperCase();
+    const hex = round(number).toString(16).toUpperCase();
     if (hex.length === 1) { return `0x0${hex}`; }
     return `0x${hex}`;
 };
 
 //---Convert to final hexadecimal
 export const toHEX = (h: number | string): string => {
-    let hex = parseInt(`${h}`).toString(16).toUpperCase();
+    let hex = round(h).toString(16).toUpperCase();
     if (hex.length === 1) {
         hex = `0${hex}`;
     }
@@ -43,8 +43,8 @@ export const getBase255Number = (color: string, alpha = false): number => {
                 : parseInt(color + color.slice(-1));
         }
         return alpha
-            ? parseInt(color) / 255
-            : parseInt(color);
+            ? round(color, MAX_DECIMALS) / 255
+            : round(color, MAX_DECIMALS);
     }
     return Math.min(+color, alpha ? 1 : 255);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,18 @@ import {
     CMYKOutput,
     ColorOutput
 } from '@types';
-import { ColorModel, Harmony, Mix } from '#constants';
-import { rgbToHSL, hslToRGB, rgbToCMYK, cmykToRGB } from '#color/translators';
+import {
+    ColorModel,
+    Harmony,
+    Mix,
+    MIN_DECIMALS
+} from '#constants';
+import {
+    rgbToHSL,
+    hslToRGB,
+    rgbToCMYK,
+    cmykToRGB
+} from '#color/translators';
 import * as utils from '#color/utils';
 import { CSS } from '#color/css';
 import { round, minmax } from '#helpers';
@@ -193,7 +203,7 @@ export class ColorTranslator {
 
     // Public alpha property
     public get A(): number {
-        return round(this.hsl.a, 2);
+        return round(this.hsl.a, MIN_DECIMALS);
     }
 
     // Public CMYK properties
@@ -233,7 +243,7 @@ export class ColorTranslator {
     public get RGBAObject(): RGBObject {
         return {
             ...this.RGBObject,
-            a: this.A
+            a: this.hsl.a
         };
     }
 
@@ -248,7 +258,7 @@ export class ColorTranslator {
     public get HSLAObject(): HSLObject {
         return {
             ...this.HSLObject,
-            a: this.A
+            a: this.hsl.a
         };
     }
 
@@ -267,7 +277,7 @@ export class ColorTranslator {
             m: this.M,
             y: this.Y,
             k: this.K,
-            a: this.A
+            a: this.hsl.a
         };
     }
 
@@ -280,7 +290,7 @@ export class ColorTranslator {
 
     public get HEXA(): string {
         const { r, g, b } = this.rgb;
-        const rgb = { r, g, b, a: this.A * 255 };
+        const rgb = { r, g, b, a: this.hsl.a * 255 };
         return CSS.HEX(rgb);
     }
 
@@ -292,7 +302,7 @@ export class ColorTranslator {
 
     public get RGBA(): string {
         const { r, g, b } = this.rgb;
-        const rgb = { r, g, b, a: this.A };
+        const rgb = { r, g, b, a: this.hsl.a };
         return CSS.RGB(rgb);
     }
 
@@ -313,7 +323,7 @@ export class ColorTranslator {
     public get CMYKA(): string {
         return CSS.CMYK({
             ...this.cmyk,
-            a: this.A
+            a: this.hsl.a
         });
     }
 

--- a/tests/color-mixing.test.ts
+++ b/tests/color-mixing.test.ts
@@ -57,7 +57,7 @@ describe('Color mixing with alphas', (): void => {
         const mix = ColorTranslator.getMixHEXA(colors);
         it(`Regular CSS additive mix with alpha using getMixHEXA ${JSON.stringify(colors)} => ${mix}`, (): void => {
             if (colors.length === 3) {
-                expect(mix.slice(-2)).toBe('B2');
+                expect(mix.slice(-2)).toBe('B3');
             } else {
                 expect(mix.slice(-2)).toBe('8E');
             }            
@@ -70,7 +70,7 @@ describe('Color mixing with alphas', (): void => {
         const mix = ColorTranslator.getMixHEXA(colors);
         it(`Regular CSS subtractive mix with alpha using getMixHEXA ${JSON.stringify(colors)} => ${mix}`, (): void => {
             if (colors.length === 3) {
-                expect(mix.slice(-2)).toBe('B2');
+                expect(mix.slice(-2)).toBe('B3');
             } else {
                 expect(mix.slice(-2)).toBe('8E');
             }            

--- a/tests/instance-set-properties.test.ts
+++ b/tests/instance-set-properties.test.ts
@@ -68,11 +68,11 @@ describe('ColorTranslator set instance properties', () => {
         instance.setA(0.5);
         expect(instance.A).toBe(0.5);
         expect(instance.HEX).toBe(TEST_COLORS.red.hex);
-        expect(instance.HEXA).toBe(TEST_COLORS.red.hex + '7F');
+        expect(instance.HEXA).toBe(TEST_COLORS.red.hex + '80');
         expect(instance.HEXObject).toMatchObject(TEST_COLORS.red.hexObject);
         expect(instance.HEXAObject).toMatchObject({
             ...TEST_COLORS.red.hexObject,
-            a: '0x7F'
+            a: '0x80'
         });
         expect(instance.RGB).toBe(TEST_COLORS.red.rgb);
         expect(instance.RGBA).toBe(TEST_COLORS.red.rgba.replace(REG, '$10.5$3'));

--- a/tests/tests.constants.ts
+++ b/tests/tests.constants.ts
@@ -441,11 +441,11 @@ export const SUBTRACTIVE_MIXES = [
 
     {
         colors: ['#FFFF00', '#FF0000'],
-        mix: '#FF7F00'
+        mix: '#FF8000'
     },
     {
         colors: ['#FF0000', '#0000FF'],
-        mix: '#7F00FF'
+        mix: '#8000FF'
     },
     {
         colors: ['#0000FF', '#FFFF00'],


### PR DESCRIPTION
The next code:

```javascript
const color = new ColorTranslator('#11223350').HEXA;
```

Was returning `#1122334F` instead of the same value (`#11223350`)

The issue was related to the rounding logic of the library.

`0x50` is `80` in decimal. So, to convert it to an alpha value is `80 / 255` which results `0.31372549019`.

The library was rounding the alphas to two values, so:

`0.31` in base `255` is `79.05` which rounded is `79` and `79` is `0x4F` in hexadecimal.

Now the rounding of the alphas is with six values, so:

`0.313725` in base `255` is `79.999875` which rounded is `80` and `80` is `0x50` in hexadecimal. 