### PR TITLE
Refactor CSS configuration options logic

### DIFF
--- a/src/color/css.ts
+++ b/src/color/css.ts
@@ -18,29 +18,28 @@ import {
 import {
     toHEX,
     round,
-    getOrderedArrayString
+    getOrderedArrayString,
+    from255NumberToPercent,
+    translateDegrees
 } from '#helpers';
 
 const getComma = (withSpace: boolean): string => withSpace
     ? ', '
     : ',';
 
-const prepareColorForCss = (color: Color, isHex = false): NumberOrString[] => {
+type Transformer = (value: NumberOrString, index?: number) => NumberOrString;
+
+const prepareColorForCss = (
+    color: Color,
+    transformer: Transformer,
+): NumberOrString[] => {
     const props = getOrderedArrayString(Object.keys(color));
     const model = VALID_COLOR_OBJECTS[props];
     const keys = COLOR_PROPS[model];
-    return keys.reduce((result: NumberOrString[], key: keyof typeof color): NumberOrString[] => {
+    return keys.reduce((result: NumberOrString[], key: keyof typeof color, index: number): NumberOrString[] => {
         const value = color[key];
         if (typeof value !== 'undefined') {
-            if (isHex) {
-                result.push(
-                    toHEX(
-                        round(value, 0)
-                    )
-                );
-            } else {
-                result.push(value);
-            }
+            result.push(transformer(value, index));
         }
         return result;
     }, []);
@@ -55,7 +54,8 @@ const getResultFromTemplate = (template: string, vars: NumberOrString[]): string
 
 export const CSS = {
     [ColorModel.HEX]: (color: HEXObject | RGBObject): string => {
-        const values = prepareColorForCss(color, true);
+        const transformer = (value: NumberOrString): string => toHEX(round(value));
+        const values = prepareColorForCss(color, transformer);
         const template = values.length === 4
             ? '#{1}{2}{3}{4}'
             : '#{1}{2}{3}';
@@ -63,56 +63,78 @@ export const CSS = {
     },
     [ColorModel.RGB]: (color: RGBObject, options: Options): string => {
         const {
+            decimals,
             legacyCSS,
             spacesAfterCommas,
             rgbUnit
         } = options;
-        const colorUnits = rgbUnit === ColorUnitEnum.PERCENT
-            ? '%'
-            : '';
         const comma = getComma(spacesAfterCommas);
-        const values = prepareColorForCss(color);
+        const transformer = (value: number, index: number): NumberOrString => {
+            return rgbUnit === ColorUnitEnum.PERCENT && index < 3
+                ?  `${from255NumberToPercent(value, decimals)}%`
+                : round(value, decimals);
+        };
+        const values = prepareColorForCss(color, transformer);
         const template = legacyCSS
             ? (
                 values.length === 4
-                    ? `rgba({1}${colorUnits}${comma}{2}${colorUnits}${comma}{3}${colorUnits}${comma}{4})`
-                    : `rgb({1}${colorUnits}${comma}{2}${colorUnits}${comma}{3}${colorUnits})`
+                    ? `rgba({1}${comma}{2}${comma}{3}${comma}{4})`
+                    : `rgb({1}${comma}{2}${comma}{3})`
             )
             : (
                 values.length === 4
-                    ? `rgb({1}${colorUnits} {2}${colorUnits} {3}${colorUnits} / {4})`
-                    : `rgb({1}${colorUnits} {2}${colorUnits} {3}${colorUnits})`
+                    ? `rgb({1} {2} {3} / {4})`
+                    : `rgb({1} {2} {3})`
             );
         return getResultFromTemplate(template, values);
     },
     [ColorModel.HSL]: (color: HSLObject, options: Options): string => {
         const {
+            decimals,
             legacyCSS,
             spacesAfterCommas,
             anglesUnit
         } = options;
         const comma = getComma(spacesAfterCommas);
-        const values = prepareColorForCss(color);
-        const angleUnits = anglesUnit === AnglesUnitEnum.NONE
-            ? ''
-            : anglesUnit;
+        const transformer = (value: number, index: number): NumberOrString => {
+            if (
+                index === 0 &&
+                anglesUnit !== AnglesUnitEnum.NONE
+            ) {
+                const translated = round(
+                    translateDegrees(
+                        value,
+                        anglesUnit
+                    ),
+                    decimals
+                );
+                return `${translated}${anglesUnit}`;
+            }
+            return round(value, decimals);
+        };
+        const values = prepareColorForCss(color, transformer);
         const template = legacyCSS
             ? (
                 values.length === 4
-                    ? `hsla({1}${angleUnits}${comma}{2}%${comma}{3}%${comma}{4})`
-                    : `hsl({1}${angleUnits}${comma}{2}%${comma}{3}%)`
+                    ? `hsla({1}${comma}{2}%${comma}{3}%${comma}{4})`
+                    : `hsl({1}${comma}{2}%${comma}{3}%)`
             )
             : (
                 values.length === 4
-                    ? `hsl({1}${angleUnits} {2}% {3}% / {4})`
-                    : `hsl({1}${angleUnits} {2}% {3}%)`
+                    ? `hsl({1} {2}% {3}% / {4})`
+                    : `hsl({1} {2}% {3}%)`
             );
         return getResultFromTemplate(template, values);
     },
     [ColorModel.CMYK]: (color: CMYKObject, options: Options): string => {
-        const { legacyCSS, spacesAfterCommas } = options;
+        const {
+            decimals,
+            legacyCSS,
+            spacesAfterCommas
+        } = options;
         const comma = getComma(spacesAfterCommas);
-        const values = prepareColorForCss(color);
+        const transformer = (value: number): number => round(value, decimals);
+        const values = prepareColorForCss(color, transformer);
         const template = legacyCSS
             ? (
                 values.length === 5


### PR DESCRIPTION
This pull request rfecators the CSS config options logic to move all the logic to the CSS module and avoid code repetition in modules not CSS related.