### PR TITLE
Implements a cmykUnit config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,16 +170,18 @@ interface Options {
   spacesAfterCommas?: boolean; // defaults to false
   anglesUnit?: 'none' | 'deg' | 'grad' | 'rad' | 'turn'; // defaults to 'none'
   rgbUnit?: 'none' | 'percent'; // defaults to 'none'
+  cmykUnit?: 'none' | 'percent'; // defaults to 'percent'
 }
 ```
 
 | Option            | Only for CSS output | Description                                                                                                    |
 | ----------------- | ------------------- | -------------------------------------------------------------------------------------------------------------- |
-| decimals          | no                  | This options set what is the maximum number of decimals for the outputs                                        |
-| legacyCSS         | yes                 | This options decides if the CSS output should be CSS Level 3 (legacy) or CSS Level 4                           |
-| spacesAfterCommas | yes                 | This options only takes place if `legacyCSS` is set to true. It decides if the comas should have a space after |
-| anglesUnit        | yes                 | This options only takes place if the output is an HSL CSS output. It sets the degrees units of the HSL hue angle. If `none` is used, the output will not have any unit but its value will be the `deg` one (degrees) |
-| rgbUnit           | yes                 | This options only takes place if the output is an RGB CSS output. It sets the color units of the output. If `none` is used the color values will be decimal between `0` and `255`. If percentages is used, the color values will be decimal with percentages between `0%` and `100%`. |
+| decimals          | no                  | This option sets what is the maximum number of decimals for the outputs                                        |
+| legacyCSS         | yes                 | This option decides if the CSS output should be CSS Level 3 (legacy) or CSS Level 4                           |
+| spacesAfterCommas | yes                 | This option only takes place if `legacyCSS` is set to true. It decides if the comas should have a space after |
+| anglesUnit        | yes                 | This option only takes place if the output is an HSL CSS output. It sets the degrees units of the HSL hue angle. If `none` is used, the output will not have any unit but its value will be the `deg` one (degrees) |
+| rgbUnit           | yes                 | This option only takes place if the output is an RGB CSS output. It sets the color units of the RGB and RGBA CSS outputs. If `none` is used the color values will be decimal between `0` and `255`. If `percent` is used, the color values will be decimal with percentages between `0%` and `100%`. |
+| cmykUnit          | yes                 | This option sets the color units of the CMYK and CMYKA CSS outputs. If `none` is used the color values will be decimal between `0` and `1`. If `percent` is used, the color values will be decimal with percentages between `0%` and `100%`. |
 
 >Note: the library tries to detect some options automatically if you don‘t send them in the options object. These are the rules for this autodetection:
 >
@@ -187,6 +189,7 @@ interface Options {
 > * `spacesAfterCommas`: if this option is set, then its value prevails, if it is not set, and the CSS input is provided with spaces after the commas, then this option will be `true`. If the input is not consistent in this aspect, then it will take its default value which is `false` (This option only takes place if `legacyCSS` is `true` or it has been autodetected as `true`)
 > * `anglesUnit`: if this option is set, then its value prevails, if it is not set, and the HSL CSS input is provided with an angle unit, then it will take that value, otherwise it will use the default one wich is `none`.
 > * `rgbUnit`: if this option is set, then its value prevails, if it is not set, and the RGB CSS input is provided with percentages in its color values, then it will take the `pcent` value, otherwise it will use the default one wich is `none`.
+> * `cmykUnit`: if this option is set, then its value prevails, if it is not set, and the CMYK CSS input is provided without percentages in its color values, then it will take the `none` value, otherwise it will use the default one wich is `percent`.
 
 ###### Class instantiation examples
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -97,14 +97,16 @@ export interface Options {
     spacesAfterCommas: boolean;
     anglesUnit: AnglesUnitEnum;
     rgbUnit: ColorUnitEnum;
+    cmykUnit: ColorUnitEnum;
 }
 
 export type InputOptions = Partial<
     Omit<
         Options,
-        'anglesUnit' | 'rgbUnit'
+        'anglesUnit' | 'rgbUnit' | 'cmykUnit'
     >
 > & {
     anglesUnit?: string;
     rgbUnit?: string;
+    cmykUnit?: string;
 };

--- a/src/color/css.ts
+++ b/src/color/css.ts
@@ -130,21 +130,32 @@ export const CSS = {
         const {
             decimals,
             legacyCSS,
-            spacesAfterCommas
+            spacesAfterCommas,
+            cmykUnit
         } = options;
         const comma = getComma(spacesAfterCommas);
-        const transformer = (value: number): number => round(value, decimals);
+        const transformer = (value: number, index: number): NumberOrString => {
+            if (
+                cmykUnit === ColorUnitEnum.PERCENT &&
+                index < 4
+            ) {
+                return `${round(value, decimals)}%`;
+            }
+            return index < 4
+                ? round(value / 100, decimals)
+                : round(value, decimals);
+        };
         const values = prepareColorForCss(color, transformer);
         const template = legacyCSS
             ? (
                 values.length === 5
-                    ? `device-cmyk({1}%${comma}{2}%${comma}{3}%${comma}{4}%${comma}{5})`
-                    : `device-cmyk({1}%${comma}{2}%${comma}{3}%${comma}{4}%)`
+                    ? `device-cmyk({1}${comma}{2}${comma}{3}${comma}{4}${comma}{5})`
+                    : `device-cmyk({1}${comma}{2}${comma}{3}${comma}{4})`
             )
             : (
                 values.length === 5
-                    ? 'device-cmyk({1}% {2}% {3}% {4}% / {5})'
-                    : 'device-cmyk({1}% {2}% {3}% {4}%)'
+                    ? 'device-cmyk({1} {2} {3} {4} / {5})'
+                    : 'device-cmyk({1} {2} {3} {4})'
             );
         return getResultFromTemplate(template, values);
     }

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -10,5 +10,6 @@ export const DEFAULT_OPTIONS: Options = {
     legacyCSS: false,
     spacesAfterCommas: false,
     anglesUnit: AnglesUnitEnum.NONE,
-    rgbUnit: ColorUnitEnum.NONE
+    rgbUnit: ColorUnitEnum.NONE,
+    cmykUnit: ColorUnitEnum.PERCENT
 };

--- a/src/constants/regexps.ts
+++ b/src/constants/regexps.ts
@@ -20,3 +20,5 @@ export const HSL_HUE = /^(-?(?:\d*\.)?\d+)((?:deg|grad|rad|turn)?)$/;
 export const PCENT = /^(\d+(?:\.\d+)?|\.\d+)%$/;
 export const HEX = /^0x([a-f\d]{1,2})$/i;
 export const TEMPLATE_VAR = /\{(\d+)\}/g;
+export const COMMAS_AND_NEXT_CHARS = /,( +|\d+)/g;
+export const SPACES = / +/;

--- a/tests/config-options.test.ts
+++ b/tests/config-options.test.ts
@@ -9,6 +9,8 @@ interface TestCase {
     rgba: string;
     hsl: string;
     hsla: string;
+    cmyk: string;
+    cmyka: string;
     isDefault: boolean;
 }
 
@@ -23,6 +25,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgba(255,0,255,1)',
             hsl: 'hsl(300,100%,50%)',
             hsla: 'hsla(300,100%,50%,1)',
+            cmyk: 'device-cmyk(0%,100%,0%,0%)',
+            cmyka: 'device-cmyk(0%,100%,0%,0%,1)',
             isDefault: false
         },
         {
@@ -31,6 +35,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgb(255 0 255 / 1)',
             hsl: 'hsl(300 100% 50%)',
             hsla: 'hsl(300 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
             isDefault: true
         },
         {
@@ -40,6 +46,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgba(255, 0, 255, 1)',
             hsl: 'hsl(300, 100%, 50%)',
             hsla: 'hsla(300, 100%, 50%, 1)',
+            cmyk: 'device-cmyk(0%, 100%, 0%, 0%)',
+            cmyka: 'device-cmyk(0%, 100%, 0%, 0%, 1)',
             isDefault: false
         },
         {
@@ -49,6 +57,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgba(255,0,255,1)',
             hsl: 'hsl(300,100%,50%)',
             hsla: 'hsla(300,100%,50%,1)',
+            cmyk: 'device-cmyk(0%,100%,0%,0%)',
+            cmyka: 'device-cmyk(0%,100%,0%,0%,1)',
             isDefault: true
         },
         {
@@ -57,6 +67,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgb(255 0 255 / 1)',
             hsl: 'hsl(300 100% 50%)',
             hsla: 'hsl(300 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
             isDefault: true
         },
         {
@@ -65,6 +77,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgb(255 0 255 / 1)',
             hsl: 'hsl(300deg 100% 50%)',
             hsla: 'hsl(300deg 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
             isDefault: false
         },
         {
@@ -73,6 +87,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgb(255 0 255 / 1)',
             hsl: 'hsl(333.333333grad 100% 50%)',
             hsla: 'hsl(333.333333grad 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
             isDefault: false
         },
         {
@@ -81,6 +97,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgb(255 0 255 / 1)',
             hsl: 'hsl(5.235988rad 100% 50%)',
             hsla: 'hsl(5.235988rad 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
             isDefault: false
         },
         {
@@ -89,6 +107,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgb(255 0 255 / 1)',
             hsl: 'hsl(0.833333turn 100% 50%)',
             hsla: 'hsl(0.833333turn 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
             isDefault: false
         },
         {
@@ -97,6 +117,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgb(255 0 255 / 1)',
             hsl: 'hsl(300 100% 50%)',
             hsla: 'hsl(300 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
             isDefault: true
         },
         {
@@ -105,6 +127,28 @@ describe('ColorTranslator CSS config options', () => {
             rgba: 'rgb(100% 0% 100% / 1)',
             hsl: 'hsl(300 100% 50%)',
             hsla: 'hsl(300 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
+            isDefault: false
+        },
+        {
+            options: { cmykUnit: 'percent' },
+            rgb: 'rgb(255 0 255)',
+            rgba: 'rgb(255 0 255 / 1)',
+            hsl: 'hsl(300 100% 50%)',
+            hsla: 'hsl(300 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
+            isDefault: true
+        },
+        {
+            options: { cmykUnit: 'none' },
+            rgb: 'rgb(255 0 255)',
+            rgba: 'rgb(255 0 255 / 1)',
+            hsl: 'hsl(300 100% 50%)',
+            hsla: 'hsl(300 100% 50% / 1)',
+            cmyk: 'device-cmyk(0 1 0 0)',
+            cmyka: 'device-cmyk(0 1 0 0 / 1)',
             isDefault: false
         }
     ];
@@ -118,6 +162,8 @@ describe('ColorTranslator CSS config options', () => {
             rgba,
             hsl,
             hsla,
+            cmyk,
+            cmyka,
             isDefault
         } = testCase;
 
@@ -128,10 +174,14 @@ describe('ColorTranslator CSS config options', () => {
             expect(instance.RGBA).toBe(rgba);
             expect(instance.HSL).toBe(hsl);
             expect(instance.HSLA).toBe(hsla);
+            expect(instance.CMYK).toBe(cmyk);
+            expect(instance.CMYKA).toBe(cmyka);
             expect(ColorTranslator.toRGB(COLOR, mergedOptions)).toBe(rgb);
             expect(ColorTranslator.toRGBA(COLOR, mergedOptions)).toBe(rgba);
             expect(ColorTranslator.toHSL(COLOR, mergedOptions)).toBe(hsl);
             expect(ColorTranslator.toHSLA(COLOR, mergedOptions)).toBe(hsla);
+            expect(ColorTranslator.toCMYK(COLOR, mergedOptions)).toBe(cmyk);
+            expect(ColorTranslator.toCMYKA(COLOR, mergedOptions)).toBe(cmyka);
         });
 
         if (isDefault) {
@@ -146,10 +196,14 @@ describe('ColorTranslator CSS config options', () => {
                 expect(instance.RGBA).toBe(rgba);
                 expect(instance.HSL).toBe(hsl);
                 expect(instance.HSLA).toBe(hsla);
+                expect(instance.CMYK).toBe(cmyk);
+                expect(instance.CMYKA).toBe(cmyka);
                 expect(ColorTranslator.toRGB(COLOR, mergedOptions)).toBe(rgb);
                 expect(ColorTranslator.toRGBA(COLOR, mergedOptions)).toBe(rgba);
                 expect(ColorTranslator.toHSL(COLOR, mergedOptions)).toBe(hsl);
                 expect(ColorTranslator.toHSLA(COLOR, mergedOptions)).toBe(hsla);
+                expect(ColorTranslator.toCMYK(COLOR, mergedOptions)).toBe(cmyk);
+                expect(ColorTranslator.toCMYKA(COLOR, mergedOptions)).toBe(cmyka);
             });
 
         }
@@ -251,6 +305,23 @@ describe('ColorTranslator CSS config options autodetection', () => {
 
         expect(ColorTranslator.toRGBA('rgba(255 0 255)')).toBe('rgb(255 0 255 / 1)');
         expect(ColorTranslator.toRGB('rgb(100% 100% 0% / 0.5)')).toBe('rgb(100% 100% 0%)');
+
+    });
+
+    it(`cmykUnit auto detection`, () => {
+
+        const instancePercentage = new ColorTranslator('device-cmyk(100% 100% 100% 100%)');
+
+        expect(instancePercentage.CMYK).toBe('device-cmyk(0% 0% 0% 100%)');
+        expect(instancePercentage.CMYKA).toBe('device-cmyk(0% 0% 0% 100% / 1)');
+
+        const instanceNone = new ColorTranslator('device-cmyk(1 1 1 1)');
+
+        expect(instanceNone.CMYK).toBe('device-cmyk(0 0 0 1)');
+        expect(instanceNone.CMYKA).toBe('device-cmyk(0 0 0 1 / 1)');
+
+        expect(ColorTranslator.toCMYK('device-cmyk(100% 100% 100% 100% / 0.5)')).toBe('device-cmyk(0% 0% 0% 100%)');
+        expect(ColorTranslator.toCMYKA('device-cmyk(1 1 1 1)')).toBe('device-cmyk(0 0 0 1 / 1)');
 
     });
 

--- a/tests/static-color-conversion.test.ts
+++ b/tests/static-color-conversion.test.ts
@@ -4,7 +4,13 @@ import { COLORS, CMYK_COLORS } from './tests.constants';
 const optionsNoLegacy = { legacyCSS: false };
 const optionsNoDecimals = { decimals: 0 };
 const optionsRgbUnitNone = { rgbUnit: 'none' };
-const options = { ...optionsNoLegacy, ...optionsNoDecimals, ...optionsRgbUnitNone };
+const optionsCmykUnitPercent = { cmykUnit: 'percent' };
+const options = {
+    ...optionsNoLegacy,
+    ...optionsNoDecimals,
+    ...optionsRgbUnitNone,
+    ...optionsCmykUnitPercent
+};
 
 COLORS.forEach((color): void => {
 
@@ -123,11 +129,11 @@ CMYK_COLORS.forEach((color) => {
             });
 
             it(`toCMYK method with decimals from ${colorValueStr}`, () => {
-                expect(ColorTranslator.toCMYK(colorValue, optionsNoLegacy)).toMatchSnapshot();
+                expect(ColorTranslator.toCMYK(colorValue, { ...optionsNoLegacy, ...optionsCmykUnitPercent })).toMatchSnapshot();
             });
 
             it(`toCMYK method with decimals and auto legacyCSS from ${colorValueStr}`, () => {
-                expect(ColorTranslator.toCMYK(colorValue)).toMatchSnapshot();
+                expect(ColorTranslator.toCMYK(colorValue, optionsCmykUnitPercent)).toMatchSnapshot();
             });
 
             it(`toCMYKObject method with decimals from ${colorValueStr}`, () => {
@@ -135,11 +141,11 @@ CMYK_COLORS.forEach((color) => {
             });
 
             it(`toCMYKA method with decimals from ${colorValueStr}`, () => {
-                expect(ColorTranslator.toCMYKA(colorValue, optionsNoLegacy)).toMatchSnapshot();
+                expect(ColorTranslator.toCMYKA(colorValue, { ...optionsNoLegacy, ...optionsCmykUnitPercent })).toMatchSnapshot();
             });
 
             it(`toCMYKA method with decimals and auto legacyCSS from ${colorValueStr}`, () => {
-                expect(ColorTranslator.toCMYKA(colorValue)).toMatchSnapshot();
+                expect(ColorTranslator.toCMYKA(colorValue, optionsCmykUnitPercent)).toMatchSnapshot();
             });
 
             it(`toCMYKAObject method with decimals from ${colorValueStr}`, () => {


### PR DESCRIPTION
This pull request implements a `cmykUnit` config option. This option sets the color units of the CMYK and CMYKA CSS outputs. If `none` is used the color values will be decimal between `0` and `1`. If `percent` is used, the color values will be decimal with percentages between `0%` and `100%`.