### PR TITLE
Implement alphaUnit config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ interface Options {
   anglesUnit?: 'none' | 'deg' | 'grad' | 'rad' | 'turn'; // defaults to 'none'
   rgbUnit?: 'none' | 'percent'; // defaults to 'none'
   cmykUnit?: 'none' | 'percent'; // defaults to 'percent'
+  alphaUnit?: 'none' | 'percent'; // defaults to 'none'
 }
 ```
 
@@ -182,6 +183,7 @@ interface Options {
 | anglesUnit        | yes                 | This option only takes place if the output is an HSL CSS output. It sets the degrees units of the HSL hue angle. If `none` is used, the output will not have any unit but its value will be the `deg` one (degrees) |
 | rgbUnit           | yes                 | This option only takes place if the output is an RGB CSS output. It sets the color units of the RGB and RGBA CSS outputs. If `none` is used the color values will be decimal between `0` and `255`. If `percent` is used, the color values will be decimal with percentages between `0%` and `100%`. |
 | cmykUnit          | yes                 | This option sets the color units of the CMYK and CMYKA CSS outputs. If `none` is used the color values will be decimal between `0` and `1`. If `percent` is used, the color values will be decimal with percentages between `0%` and `100%`. |
+| alphaUnit         | yes                 | This option only takes place if the output is a CSS Level 4 output (`legacyCSS` has not been set, or it has been set to `false` or it has been autodetected as `false`). This option sets the alpha units of the CSS Level 4 outputs. If `none` is used the alpha values will be decimal between `0` and `1`. If `percent` is used, the alpha values will be decimal with percentages between `0%` and `100%`. |
 
 >Note: the library tries to detect some options automatically if you don‘t send them in the options object. These are the rules for this autodetection:
 >
@@ -190,6 +192,7 @@ interface Options {
 > * `anglesUnit`: if this option is set, then its value prevails, if it is not set, and the HSL CSS input is provided with an angle unit, then it will take that value, otherwise it will use the default one wich is `none`.
 > * `rgbUnit`: if this option is set, then its value prevails, if it is not set, and the RGB CSS input is provided with percentages in its color values, then it will take the `pcent` value, otherwise it will use the default one wich is `none`.
 > * `cmykUnit`: if this option is set, then its value prevails, if it is not set, and the CMYK CSS input is provided without percentages in its color values, then it will take the `none` value, otherwise it will use the default one wich is `percent`.
+> * `alphaUnit`: if this option is set, then its value prevails, if it is not set, and the CSS input (must be CSS Level 4) is provided with percentages in its alpha value, then it will take the `percent` value, otherwise it will use the default one wich is `none`.
 
 ###### Class instantiation examples
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -98,15 +98,17 @@ export interface Options {
     anglesUnit: AnglesUnitEnum;
     rgbUnit: ColorUnitEnum;
     cmykUnit: ColorUnitEnum;
+    alphaUnit: ColorUnitEnum;
 }
 
 export type InputOptions = Partial<
     Omit<
         Options,
-        'anglesUnit' | 'rgbUnit' | 'cmykUnit'
+        'anglesUnit' | 'rgbUnit' | 'cmykUnit' | 'alphaUnit'
     >
 > & {
     anglesUnit?: string;
     rgbUnit?: string;
     cmykUnit?: string;
+    alphaUnit?: string;
 };

--- a/src/color/css.ts
+++ b/src/color/css.ts
@@ -52,6 +52,14 @@ const getResultFromTemplate = (template: string, vars: NumberOrString[]): string
     });
 };
 
+const getAlpha = (value: number, options: Options): NumberOrString => {
+    const { alphaUnit, legacyCSS, decimals } = options;
+    if (alphaUnit === ColorUnitEnum.PERCENT && !legacyCSS) {
+        return `${round(value * 100, decimals)}%`;
+    }
+    return round(value, decimals);
+};
+
 export const CSS = {
     [ColorModel.HEX]: (color: HEXObject | RGBObject): string => {
         const transformer = (value: NumberOrString): string => toHEX(round(value));
@@ -72,7 +80,11 @@ export const CSS = {
         const transformer = (value: number, index: number): NumberOrString => {
             return rgbUnit === ColorUnitEnum.PERCENT && index < 3
                 ?  `${from255NumberToPercent(value, decimals)}%`
-                : round(value, decimals);
+                : (
+                    index === 3
+                        ? getAlpha(value, options)
+                        : round(value, decimals)
+                );
         };
         const values = prepareColorForCss(color, transformer);
         const template = legacyCSS
@@ -110,7 +122,9 @@ export const CSS = {
                 );
                 return `${translated}${anglesUnit}`;
             }
-            return round(value, decimals);
+            return index === 3
+                ? getAlpha(value, options)
+                : round(value, decimals);
         };
         const values = prepareColorForCss(color, transformer);
         const template = legacyCSS
@@ -141,9 +155,9 @@ export const CSS = {
             ) {
                 return `${round(value, decimals)}%`;
             }
-            return index < 4
-                ? round(value / 100, decimals)
-                : round(value, decimals);
+            return index === 4
+                ? getAlpha(value, options)
+                : round(value / 100, decimals);
         };
         const values = prepareColorForCss(color, transformer);
         const template = legacyCSS

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -11,5 +11,6 @@ export const DEFAULT_OPTIONS: Options = {
     spacesAfterCommas: false,
     anglesUnit: AnglesUnitEnum.NONE,
     rgbUnit: ColorUnitEnum.NONE,
-    cmykUnit: ColorUnitEnum.PERCENT
+    cmykUnit: ColorUnitEnum.PERCENT,
+    alphaUnit: ColorUnitEnum.NONE
 };

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -158,6 +158,7 @@ export const getOptionsFromColorInput = (options: InputOptions, ...colors: Color
     const hslColors: AnglesUnitEnum[] = [];
     const rgbColors: boolean[] = [];
     const cmykColors: boolean[] = [];
+    const alphaValues: boolean[] = [];
 
     const matchOptions: MatchOptions = {
         legacyCSS: 0,
@@ -184,11 +185,15 @@ export const getOptionsFromColorInput = (options: InputOptions, ...colors: Color
             if (color.match(COLORREGS.HSL)) {
                 const match = color.match(COLORREGS.HSL);
                 const angle = match[1] || match[5];
-                const unit = angle.match(HSL_HUE)[2];
+                const alpha = match[8];
+                const angleUnit = angle.match(HSL_HUE)[2];
                 hslColors.push(
-                    unit === ''
+                    angleUnit === ''
                         ? AnglesUnitEnum.NONE
-                        : unit as AnglesUnitEnum
+                        : angleUnit as AnglesUnitEnum
+                );
+                alphaValues.push(
+                    PCENT.test(alpha)
                 );
                 continue;
             }
@@ -198,10 +203,14 @@ export const getOptionsFromColorInput = (options: InputOptions, ...colors: Color
                 const r = match[1] || match[5];
                 const g = match[2] || match[6];
                 const b = match[3] || match[7];
+                const a = match[8];
                 rgbColors.push(
                     PCENT.test(r) &&
                     PCENT.test(g) &&
                     PCENT.test(b)
+                );
+                alphaValues.push(
+                    PCENT.test(a)
                 );
                 continue;
             }
@@ -212,11 +221,15 @@ export const getOptionsFromColorInput = (options: InputOptions, ...colors: Color
                 const m = match[2] || match[7];
                 const y = match[3] || match[8];
                 const k = match[4] || match[9];
+                const a = match[10];
                 cmykColors.push(
                     PCENT.test(c) &&
                     PCENT.test(m) &&
                     PCENT.test(y) &&
                     PCENT.test(k)
+                );
+                alphaValues.push(
+                    PCENT.test(a)
                 );
             }
 
@@ -259,6 +272,13 @@ export const getOptionsFromColorInput = (options: InputOptions, ...colors: Color
                 new Set(cmykColors).size === 1 && !cmykColors[0]
                     ? ColorUnitEnum.NONE
                     : DEFAULT_OPTIONS.cmykUnit
+            ),
+        alphaUnit: options.alphaUnit
+            ? options.alphaUnit as ColorUnitEnum
+            : (
+                new Set(alphaValues).size === 1 && alphaValues[0]
+                    ? ColorUnitEnum.PERCENT
+                    : DEFAULT_OPTIONS.alphaUnit
             )
     };
 };

--- a/tests/config-options.test.ts
+++ b/tests/config-options.test.ts
@@ -150,6 +150,26 @@ describe('ColorTranslator CSS config options', () => {
             cmyk: 'device-cmyk(0 1 0 0)',
             cmyka: 'device-cmyk(0 1 0 0 / 1)',
             isDefault: false
+        },
+        {
+            options: { alphaUnit: 'none' },
+            rgb: 'rgb(255 0 255)',
+            rgba: 'rgb(255 0 255 / 1)',
+            hsl: 'hsl(300 100% 50%)',
+            hsla: 'hsl(300 100% 50% / 1)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 1)',
+            isDefault: true
+        },
+        {
+            options: { alphaUnit: 'percent' },
+            rgb: 'rgb(255 0 255)',
+            rgba: 'rgb(255 0 255 / 100%)',
+            hsl: 'hsl(300 100% 50%)',
+            hsla: 'hsl(300 100% 50% / 100%)',
+            cmyk: 'device-cmyk(0% 100% 0% 0%)',
+            cmyka: 'device-cmyk(0% 100% 0% 0% / 100%)',
+            isDefault: false
         }
     ];
 
@@ -322,6 +342,33 @@ describe('ColorTranslator CSS config options autodetection', () => {
 
         expect(ColorTranslator.toCMYK('device-cmyk(100% 100% 100% 100% / 0.5)')).toBe('device-cmyk(0% 0% 0% 100%)');
         expect(ColorTranslator.toCMYKA('device-cmyk(1 1 1 1)')).toBe('device-cmyk(0 0 0 1 / 1)');
+
+    });
+
+    it(`alphaUnit auto detection`, () => {
+
+        const regNone = /^.* \/ 0\.5\)$/;
+        const regPercent = /^.* \/ 50%\)$/;
+        const instanceAlphaNone = new ColorTranslator('rgb(255 0 255 / 0.5)');
+
+        expect(instanceAlphaNone.HSLA).toBe('hsl(300 100% 50% / 0.5)');
+        expect(instanceAlphaNone.RGBA).toBe('rgb(255 0 255 / 0.5)');
+        expect(regNone.test(instanceAlphaNone.CMYKA)).toBe(true);
+
+        const instanceAlphaPercentage = new ColorTranslator('rgb(255 0 255 / 50%)');
+
+        expect(instanceAlphaPercentage.HSLA).toBe('hsl(300 100% 50% / 50%)');
+        expect(instanceAlphaPercentage.RGBA).toBe('rgb(255 0 255 / 50%)');
+        expect(regPercent.test(instanceAlphaPercentage.CMYKA)).toBe(true);
+
+        expect(ColorTranslator.toHSLA('rgb(255 0 255 / 0.5)')).toBe('hsl(300 100% 50% / 0.5)');
+        expect(ColorTranslator.toRGBA('rgb(255 0 255 / 0.5)')).toBe('rgb(255 0 255 / 0.5)');
+        expect(regNone.test(ColorTranslator.toCMYKA('rgb(255 0 255 / 0.5)'))).toBe(true);
+
+        expect(ColorTranslator.toHSLA('rgb(255 0 255 / 80%)')).toBe('hsl(300 100% 50% / 80%)');
+        expect(ColorTranslator.toRGBA('rgb(255 0 255 / 5%)')).toBe('rgb(255 0 255 / 5%)');
+        expect(regPercent.test(ColorTranslator.toCMYKA('rgb(255 0 255 / 50%)'))).toBe(true);
+
 
     });
 

--- a/tests/static-color-conversion.test.ts
+++ b/tests/static-color-conversion.test.ts
@@ -5,11 +5,13 @@ const optionsNoLegacy = { legacyCSS: false };
 const optionsNoDecimals = { decimals: 0 };
 const optionsRgbUnitNone = { rgbUnit: 'none' };
 const optionsCmykUnitPercent = { cmykUnit: 'percent' };
+const optionsAlphaUnitNone = { alphaUnit: 'none' };
 const options = {
     ...optionsNoLegacy,
     ...optionsNoDecimals,
     ...optionsRgbUnitNone,
-    ...optionsCmykUnitPercent
+    ...optionsCmykUnitPercent,
+    ...optionsAlphaUnitNone
 };
 
 COLORS.forEach((color): void => {
@@ -141,11 +143,11 @@ CMYK_COLORS.forEach((color) => {
             });
 
             it(`toCMYKA method with decimals from ${colorValueStr}`, () => {
-                expect(ColorTranslator.toCMYKA(colorValue, { ...optionsNoLegacy, ...optionsCmykUnitPercent })).toMatchSnapshot();
+                expect(ColorTranslator.toCMYKA(colorValue, { ...optionsNoLegacy, ...optionsCmykUnitPercent, ...optionsAlphaUnitNone })).toMatchSnapshot();
             });
 
             it(`toCMYKA method with decimals and auto legacyCSS from ${colorValueStr}`, () => {
-                expect(ColorTranslator.toCMYKA(colorValue, optionsCmykUnitPercent)).toMatchSnapshot();
+                expect(ColorTranslator.toCMYKA(colorValue, { ...optionsCmykUnitPercent, ...optionsAlphaUnitNone })).toMatchSnapshot();
             });
 
             it(`toCMYKAObject method with decimals from ${colorValueStr}`, () => {


### PR DESCRIPTION
This pull request implements a new config option (`alphaUnit`). This option only takes place if the output is a CSS Level 4 output (`legacyCSS` has not been set, or it has been set to `false` or it has been autodetected as `false`). This option sets the alpha units of the CSS Level 4 outputs. If `none` is used the alpha values will be decimal between `0` and `1`. If `percent` is used, the alpha values will be decimal with percentages between `0%` and `100%`.