### PR TITLE
Avoid double rounding in blending static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.1] - 2023-07-20
+
+- Avoid double rounding in CSS blending static methods
+
 ## [3.0.0] - 2023-07-18
 
 - [BREAKING CHANGE]: Complete refactoring of the library, now the default CSS output is in CSS Level 4, if one wants CSS Level 3 it should be required through a configuration parameter. The new API can be consulted in the README.

--- a/src/index.ts
+++ b/src/index.ts
@@ -624,7 +624,13 @@ export class ColorTranslator {
         steps: number = DEFAULT_BLEND_STEPS,
         options: InputOptions = {}
     ): string[] {
-        return ColorTranslator.getBlendRGBObject(from, to, steps, options)
+        return getBlendReturn<RGBObject>(
+            from,
+            to,
+            steps,
+            MAX_DECIMALS,
+            utils.translateColor.RGB
+        )
             .map((color: RGBObject): string => {
                 return CSS.RGB(
                     color,
@@ -654,7 +660,13 @@ export class ColorTranslator {
         steps: number = DEFAULT_BLEND_STEPS,
         options: InputOptions = {}
     ): string[] {
-        return ColorTranslator.getBlendRGBAObject(from, to, steps, options)
+        return getBlendReturn<RGBObject>(
+            from,
+            to,
+            steps,
+            MAX_DECIMALS,
+            utils.translateColor.RGBA
+        )
             .map((color: RGBObject): string => {
                 return CSS.RGB(
                     color,
@@ -685,7 +697,13 @@ export class ColorTranslator {
         options: InputOptions = {}
     ): string[] {
         const detectedOptions = getOptionsFromColorInput(options, from, to);
-        return ColorTranslator.getBlendHSLObject(from, to, steps, options)
+        return getBlendReturn<HSLObject>(
+            from,
+            to,
+            steps,
+            MAX_DECIMALS,
+            utils.translateColor.HSL
+        )
             .map((color: HSLObject) => {
                 return CSS.HSL(color, detectedOptions);
             });
@@ -713,7 +731,13 @@ export class ColorTranslator {
         options: InputOptions = {}
     ): string[] {
         const detectedOptions = getOptionsFromColorInput(options, from, to);
-        return ColorTranslator.getBlendHSLAObject(from, to, steps, options)
+        return getBlendReturn<HSLObject>(
+            from,
+            to,
+            steps,
+            MAX_DECIMALS,
+            utils.translateColor.HSLA
+        )
             .map((color: HSLObject): string => {
                 return CSS.HSL(color, detectedOptions);
             });


### PR DESCRIPTION
This pull request avoids rounding the color values twice in the CSS blending static methods.