### PR TITLE
Specify types for ESM module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.2] - 2023-08-02
+
+- Specify types for the ESM bundle
+
 ## [3.0.1] - 2023-07-20
 
 - Avoid double rounding in CSS blending static methods

--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "require": "./index.js",
-      "import": "./esm/index.js"
+      "require": {
+        "default": "./index.js",
+        "types": "./index.d.ts"
+      },
+      "import": {
+        "default": "./esm/index.js",
+        "types": "./index.d.ts"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
This pull request adds types to the exports definitions as recommended in [the HandBook](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing). This is to avoid TypeScript complaining about:

```
Could not find a declaration file for module 'colortranslator'. '/path-to-project/node_modules/colortranslator/esm/index.js' implicitly has an 'any' type.
  There are types at '/path-to-project/node_modules/colortranslator/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'colortranslator' library may need to update its package.json or typings.ts(7016)
```