### PR TITLE
Provide to d.ts files, one for CommonJS and another for ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.0.2] - 2023-08-02
 
 - Specify types for the ESM bundle
+- Provide types specifically for the ESM bundle
 
 ## [3.0.1] - 2023-07-20
 

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "require": {
-        "default": "./index.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./index.js"        
       },
       "import": {
-        "default": "./esm/index.js",
-        "types": "./index.d.ts"
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"        
       }
     }
   },

--- a/scripts/finish.sh
+++ b/scripts/finish.sh
@@ -2,7 +2,6 @@
 
 mkdir -p dist/web/
 
-rm esm/index.d.ts
 rm web/colortranslator.d.ts
 cp web/colortranslator.js dist/web/colortranslator.js
 echo '{\n    "type": "module"\n}' > esm/package.json


### PR DESCRIPTION
Following the recommendations in [the HandBook](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing):

* The "types" condition should always come first in "exports".
* It’s important to note that the CommonJS entrypoint and the ES module entrypoint each needs its own declaration file, even if the contents are the same between them. Every declaration file is interpreted either as a CommonJS module or as an ES module, based on its file extension and the `"type"` field of the `package.json`, and this detected module kind must match the module kind that Node will detect for the corresponding JavaScript file for type checking to be correct. Attempting to use a single `.d.ts` file to type both an ES module entrypoint and a CommonJS entrypoint will cause TypeScript to think only one of those entrypoints exists, causing compiler errors for users of the package.