### PR TITLE
Improve overloads and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve `getHarmony` method overloads to make it possible to omit optional parameters
 - Improve types for `Mix` and `Harmony` making it possible to send also strings
 - Fix a bug in the `getBlendXXX` which was ignoring the `decimals` sent and always suing `MAX_DECIMALS`
+- Fix `CIELabObject` not being exported with the library
 
 ## [4.0.0] - 2023-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Improve `getHarmony` method overloads to make it possible to omit optional parameters
 - Improve types for `Mix` and `Harmony` making it possible to send also strings
 - Make optional the `shades` and `tints` parameters of the `getShades` and `getTints` methods respectively
-- Fix a bug in the `getBlendXXX` which was ignoring the `decimals` sent and always suing `MAX_DECIMALS`
+- Fix a bug in the `getBlendXXX` and `toXXX` methods which were ignoring the `decimals` sent and always using `MAX_DECIMALS`
 - Fix `CIELabObject` not being exported with the library
 
 ## [4.0.0] - 2023-11-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Improve `getMixXXX` methods overloads to make it possible to omit optional parameters
 - Improve `getHarmony` method overloads to make it possible to omit optional parameters
 - Improve types for `Mix` and `Harmony` making it possible to send also strings
+- Make optional the `shades` and `tints` parameters of the `getShades` and `getTints` methods respectively
 - Fix a bug in the `getBlendXXX` which was ignoring the `decimals` sent and always suing `MAX_DECIMALS`
 - Fix `CIELabObject` not being exported with the library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.1.0] - 2023-11-27
+
+- Improve `getBlendXXX` methods overloads to make it possible to omit optional parameters
+- Improve `getMixXXX` methods overloads to make it possible to omit optional parameters
+- Improve `getHarmony` method overloads to make it possible to omit optional parameters
+- Improve types for `Mix` and `Harmony` making it possible to send also strings
+- Fix a bug in the `getBlendXXX` which was ignoring the `decimals` sent and always suing `MAX_DECIMALS`
+
 ## [4.0.0] - 2023-11-26
 
 - [BREAKING CHANGE]: Properties of the HEX, HEXA, RGB, RGBA, HSL, HSLA, CMYK and CMYKA objects are now capitalized letters to make them more consistent with the rest of the properties and to add support for `Lab` colors with alpha (`L a b A`)

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ getBlendColorsStaticMethod(
 getBlendColorsStaticMethod(
   fromColor: string | object,
   toColor: string | object,
-  steps?: number,
+  steps: number,
   options?: Options
 )
 ```
@@ -594,7 +594,7 @@ getMixColorsStaticMethod(
 // Specifying the mix mode
 getMixColorsStaticMethod(
   colors: [string | object][],
-  mode?: 'ADDITIVE' | 'SUBTRACTIVE',
+  mode: 'ADDITIVE' | 'SUBTRACTIVE',
   options?: Options
 )
 ```
@@ -647,12 +647,26 @@ You can also consult the [demo 8](https://elchininet.github.io/ColorTranslator/#
 The static methods to get [shades or tints of a color](https://en.m.wikipedia.org/wiki/Tints_and_shades) accept any of the mentioned inputs as the first parameter. The second parameter specifies the number of shades or tints that should be returned and the third parameter is optional and it is an [options object](#options-object). This method will return the colors in the same format that was sent as input:
 
 ```typescript
+// If shades is not sent, the default will be 5
+getShades(
+  color: string | object,
+  options?: Options
+)
+
+// Specifying the shades number
 getShades(
   color: string | object,
   shades: number,
   options?: Options
 )
 
+// If tints is not sent, the default will be 5
+getTints(
+  color: string | object,
+  options?: Options
+)
+
+// Specifying the tints number
 getTints(
   color: string | object,
   tints: number,
@@ -709,14 +723,14 @@ getHarmony(
 // If mode is not sent, the default will be "ADDITIVE"
 getHarmony(
   color: string | object,
-  harmony?: 'ANALOGOUS' | 'COMPLEMENTARY' | 'SPLIT_COMPLEMENTARY' | 'TRIADIC' | 'TETRADIC' | 'SQUARE',
+  harmony: 'ANALOGOUS' | 'COMPLEMENTARY' | 'SPLIT_COMPLEMENTARY' | 'TRIADIC' | 'TETRADIC' | 'SQUARE',
   options?: Options
 )
 
 // If harmony is not sent, the default will be "COMPLEMENTARY"
 getHarmony(
   color: string | object,
-  mode?: 'ADDITIVE' | 'SUBTRACTIVE',
+  mode: 'ADDITIVE' | 'SUBTRACTIVE',
   options?: Options
 )
 

--- a/README.md
+++ b/README.md
@@ -507,10 +507,18 @@ You can also consult the [demo 3](https://elchininet.github.io/ColorTranslator/#
 The static methods to create color blends accept any of the mentioned inputs as the first and second parameter, the third parameter is optional and it is the number of steps of the blending. And the fourth parameter is also optional and it is an [options object](#options-object) (this fourth option is not present in the methods to generate HEX colors):
 
 ```typescript
+// If steps is not sent, the default will be 5
 getBlendColorsStaticMethod(
   fromColor: string | object,
   toColor: string | object,
-  steps: number = 5,
+  options?: Options
+)
+
+// Specifying the number of steps
+getBlendColorsStaticMethod(
+  fromColor: string | object,
+  toColor: string | object,
+  steps?: number,
   options?: Options
 )
 ```
@@ -572,14 +580,21 @@ You can also consult the [demo 6](https://elchininet.github.io/ColorTranslator/#
 
 ###### Color mix static methods
 
-The static methods to mix colors accept an array of any of the mentioned inputs as the first parameter. The second parameter is optional and specifies the mixing mode (by default it will be `Mix.ADDITIVE`). And the third parameter is also optional and it is an [options object](#options-object) (this third option is not present in the methods to generate HEX colors):
+The static methods to mix colors accept an array of any of the mentioned inputs as the first parameter. The second parameter is optional and specifies the mixing mode (by default it will be `ADDITIVE`). And the third parameter is also optional and it is an [options object](#options-object) (this third option is not present in the methods to generate HEX colors):
 
 > **Note:** The subtractive mix simulates the mixing of pigments, to achieve this, the rgb colors are converted to ryb color model, the addition is performed in this mode and at the end the result is converted back to rgb. The result is OK most of the time, but as this is not a real mix of pigments, sometimes the result could differ from the reality.
 
 ```typescript
+// If mode is not sent, the default will be "ADDITIVE"
 getMixColorsStaticMethod(
   colors: [string | object][],
-  mode: Mix = Mix.ADDITIVE,
+  options?: Options
+)
+
+// Specifying the mix mode
+getMixColorsStaticMethod(
+  colors: [string | object][],
+  mode?: 'ADDITIVE' | 'SUBTRACTIVE',
   options?: Options
 )
 ```
@@ -616,11 +631,11 @@ ColorTranslator.getMixHSL(['rgba(255, 0, 0, 1)', '#00FF00']);
 
 // hsl(60 100% 50%)
 
-ColorTranslator.getMixHEXAObject(['#F00', 'rgb(0, 0, 255)'], Mix.ADDITIVE);
+ColorTranslator.getMixHEXAObject(['#F00', 'rgb(0, 0, 255)'], 'ADDITIVE');
 
 // { R: '0xFF', G: '0x00', B: '0xFF', A: '0xFF' }
 
-ColorTranslator.getMixHEX(['#FF0', '#F00'], Mix.SUBTRACTIVE);
+ColorTranslator.getMixHEX(['#FF0', '#F00'], 'SUBTRACTIVE');
 
 // #FF8800
 ```
@@ -681,13 +696,34 @@ You can also consult the [demo 7](https://elchininet.github.io/ColorTranslator/#
 
 ###### Color harmonies static method
 
-The static method to create color harmonies accepts four parmeters, the first one could be any of the mentioned inputs, the second one is optional and it is to specify the kind of harmony (by default it will be `Harmony.COMPLEMENTARY`), the third one is also optional and it specifies if the returned harmony is based on additive or subtractive colors (by default it will be `Mix.ADDITIVE`), and the fourth parameter is also optional and it is an [options object](#options-object). This method will return the colors in the same format that was sent as input:
+The static method to create color harmonies accepts four parmeters, the first one could be any of the mentioned inputs, the second one is optional and it is to specify the kind of harmony (by default it will be "COMPLEMENTARY"), the third one is also optional and it specifies if the returned harmony is based on additive or subtractive colors (by default it will be "ADDITIVE"), and the fourth parameter is also optional and it is an [options object](#options-object). This method will return the colors in the same format that was sent as input:
 
 ```typescript
+// If harmony is not sent, the default will be "COMPLEMENTARY"
+// If mode is not sent, the default will be "ADDITIVE"
 getHarmony(
-  color: string | object
-  harmony: Harmony = Harmony.COMPLEMENTARY,
-  mode: Mix = Mix.ADDITIVE,
+  color: string | object,
+  options?: Options
+)
+
+// If mode is not sent, the default will be "ADDITIVE"
+getHarmony(
+  color: string | object,
+  harmony?: 'ANALOGOUS' | 'COMPLEMENTARY' | 'SPLIT_COMPLEMENTARY' | 'TRIADIC' | 'TETRADIC' | 'SQUARE',
+  options?: Options
+)
+
+// If harmony is not sent, the default will be "COMPLEMENTARY"
+getHarmony(
+  color: string | object,
+  mode?: 'ADDITIVE' | 'SUBTRACTIVE',
+  options?: Options
+)
+
+getHarmony(
+  color: string | object,
+  harmony: 'ANALOGOUS' | 'COMPLEMENTARY' | 'SPLIT_COMPLEMENTARY' | 'TRIADIC' | 'TETRADIC' | 'SQUARE',
+  mode: 'ADDITIVE' | 'SUBTRACTIVE',
   options?: Options
 )
 ```
@@ -716,7 +752,7 @@ ColorTranslator.getHarmony('#FF00FF');
 
 // ["#FF00FF", "#00FF00"]
 
-ColorTranslator.getHarmony('rgba(0 255 255 / 0.5)', Harmony.ANALOGOUS);
+ColorTranslator.getHarmony('rgba(0 255 255 / 0.5)', 'ANALOGOUS');
 
 // [
 //   "rgba(0 255 255 / 0.5)",
@@ -726,8 +762,8 @@ ColorTranslator.getHarmony('rgba(0 255 255 / 0.5)', Harmony.ANALOGOUS);
 
 ColorTranslator.getHarmony(
   { r: 115, g: 200, b: 150, a: 0.5 },
-  Harmony.COMPLEMENTARY,
-  Mix.ADDITIVE,
+  'COMPLEMENTARY',
+  'ADDITIVE',
   { decimals: 2 }
 );
 
@@ -736,7 +772,7 @@ ColorTranslator.getHarmony(
 //   {R: 200, G: 123.75, B: 115, A: 0.5}
 // ]
 
-ColorTranslator.getHarmony('#FF0000', Harmony.COMPLEMENTARY, Mix.SUBTRACTIVE);
+ColorTranslator.getHarmony('#FF0000', 'COMPLEMENTARY', 'SUBTRACTIVE');
 
 // ["#FF0000", "#00FF00"]
 
@@ -746,7 +782,16 @@ You can also consult the [demo 10](https://elchininet.github.io/ColorTranslator/
 
 ## TypeScript Support
 
-The package has its own type definitions, so it can be used in a `TypeScript` project without any issues. The next interfaces are exposed and can be imported in your project:
+The package has its own type definitions, so it can be used in a `TypeScript` project without any issues. The next enums and interfaces are exposed and can be imported in your project:
+
+###### Harmony and Mix
+
+You can send these values as strings and it will be checked by `TypeScript` if the string is correct. But for comodity, you can use the `Harmony` and `Mix` enums exported in the library.
+
+```typescript
+Harmony.COMPLEMENTARY === 'COMPLEMENTARY';
+Mix.ADDITIVE === 'ADDITIVE'
+```
 
 ###### InputOptions
 

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -25,6 +25,7 @@ import {
     PCENT,
     ColorModel,
     Mix,
+    MixString,
     ColorKeywords,
     COLORREGS,
     COLOR_KEYS,
@@ -58,7 +59,7 @@ import {
 } from '#color/translators';
 import { CSS } from '#color/css';
 
-type HarmonyFunction = (color: HSLObject, mode: Mix) => HSLObject[];
+type HarmonyFunction = (color: HSLObject, mode: MixString) => HSLObject[];
 
 //---Normalize alpha
 export const normalizeAlpha = (alpha: number | string | undefined | null): number => {
@@ -76,7 +77,7 @@ export const normalizeAlpha = (alpha: number | string | undefined | null): numbe
 const harmony = (
     color: HSLObject,
     angles: number[],
-    mode: Mix
+    mode: MixString
 ): HSLObject[] =>
     angles.reduce(
         (arr: HSLObject[], num: number): HSLObject[] =>
@@ -93,12 +94,12 @@ const harmony = (
             ), [{...color}]
     );
 
-export const analogous          = (color: HSLObject, mode: Mix): HSLObject[] => harmony(color, [30, -30], mode);
-export const complementary      = (color: HSLObject, mode: Mix): HSLObject[] => harmony(color, [180], mode);
-export const splitComplementary = (color: HSLObject, mode: Mix): HSLObject[] => harmony(color, [150, -150], mode);
-export const triadic            = (color: HSLObject, mode: Mix): HSLObject[] => harmony(color, [120, -120], mode);
-export const tetradic           = (color: HSLObject, mode: Mix): HSLObject[] => harmony(color, [60, -120, 180], mode);
-export const square             = (color: HSLObject, mode: Mix): HSLObject[] => harmony(color, [90, -90, 180], mode);
+export const analogous          = (color: HSLObject, mode: MixString): HSLObject[] => harmony(color, [30, -30], mode);
+export const complementary      = (color: HSLObject, mode: MixString): HSLObject[] => harmony(color, [180], mode);
+export const splitComplementary = (color: HSLObject, mode: MixString): HSLObject[] => harmony(color, [150, -150], mode);
+export const triadic            = (color: HSLObject, mode: MixString): HSLObject[] => harmony(color, [120, -120], mode);
+export const tetradic           = (color: HSLObject, mode: MixString): HSLObject[] => harmony(color, [60, -120, 180], mode);
+export const square             = (color: HSLObject, mode: MixString): HSLObject[] => harmony(color, [90, -90, 180], mode);
 
 //---Detect the color model from an string
 const getColorModelFromString = (color: string): ColorModel => {
@@ -498,7 +499,7 @@ export const colorHarmony = {
     buildHarmony(
         color: ColorInputWithoutCMYK,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         options: Options
     ): ColorOutput[] {
         const model = getColorModel(color);
@@ -543,7 +544,7 @@ export const colorHarmony = {
     [ColorModel.HEX](
         color: HSLObject,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         css: boolean
     ): HEXOutput[] {
         const array = harmonyFunction(color, mode);
@@ -563,7 +564,7 @@ export const colorHarmony = {
     HEXA(
         color: HSLObject,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         css: boolean
     ): HEXOutput[] {
         const array = harmonyFunction(color, mode);
@@ -587,7 +588,7 @@ export const colorHarmony = {
     [ColorModel.RGB](
         color: HSLObject,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         css: boolean,
         options: Options
     ): RGBOutput[] {
@@ -610,7 +611,7 @@ export const colorHarmony = {
     RGBA(
         color: HSLObject,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         css: boolean,
         options: Options
     ): RGBOutput[] {
@@ -639,7 +640,7 @@ export const colorHarmony = {
     [ColorModel.HSL](
         color: HSLObject,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         css: boolean,
         options: Options
     ): HSLOutput[] {
@@ -666,7 +667,7 @@ export const colorHarmony = {
     HSLA(
         color: HSLObject,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         css: boolean,
         options: Options
     ): HSLOutput[] {
@@ -695,7 +696,7 @@ export const colorHarmony = {
     [ColorModel.CIELab](
         color: HSLObject,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         css: boolean,
         options: Options
     ): CIELabOutput[] {
@@ -725,7 +726,7 @@ export const colorHarmony = {
     CIELabA(
         color: HSLObject,
         harmonyFunction: HarmonyFunction,
-        mode: Mix,
+        mode: MixString,
         css: boolean,
         options: Options
     ): CIELabOutput[] {
@@ -761,7 +762,7 @@ export const colorHarmony = {
 
 export const colorMixer = {
 
-    mix(colors: ColorInput[], mode: Mix): RGBObject {
+    mix(colors: ColorInput[], mode: MixString): RGBObject {
 
         const rgbMap = colors.map((color: ColorInput): RGBObject => {
             const model = getColorModel(color);
@@ -826,7 +827,7 @@ export const colorMixer = {
     },
     [ColorModel.HEX]<CSS extends boolean, R = CSS extends true ? string : HEXObject>(
         colors: ColorInput[],
-        mode: Mix,
+        mode: MixString,
         css: CSS
     ): R {
         const mix = this.mix(colors, mode);
@@ -839,7 +840,7 @@ export const colorMixer = {
     },
     HEXA<CSS extends boolean, R = CSS extends true ? string : HEXObject >(
         colors: ColorInput[],
-        mode: Mix,
+        mode: MixString,
         css: CSS
     ): R {
         const mix = this.mix(colors, mode);
@@ -854,7 +855,7 @@ export const colorMixer = {
     },
     [ColorModel.RGB]<CSS extends boolean, R = CSS extends true ? string : RGBObject>(
         colors: ColorInput[],
-        mode: Mix,
+        mode: MixString,
         css: CSS,
         options: Options
     ): R {
@@ -868,7 +869,7 @@ export const colorMixer = {
     },
     RGBA<CSS extends boolean, R = CSS extends true ? string : RGBObject>(
         colors: ColorInput[],
-        mode: Mix,
+        mode: MixString,
         css: CSS,
         options: Options
     ): R {
@@ -881,7 +882,7 @@ export const colorMixer = {
     },
     [ColorModel.HSL]<CSS extends boolean, R = CSS extends true ? string : HSLObject>(
         colors: ColorInput[],
-        mode: Mix,
+        mode: MixString,
         css: CSS,
         options: Options
     ): R {
@@ -897,7 +898,7 @@ export const colorMixer = {
     },
     HSLA<CSS extends boolean, R = CSS extends true ? string : HSLObject>(
         colors: ColorInput[],
-        mode: Mix,
+        mode: MixString,
         css: CSS,
         options: Options
     ): R {
@@ -911,7 +912,7 @@ export const colorMixer = {
     },
     [ColorModel.CIELab]<CSS extends boolean, R = CSS extends true ? string : CIELabObject>(
         colors: ColorInput[],
-        mode: Mix,
+        mode: MixString,
         css: CSS,
         options: Options
     ): R {
@@ -926,7 +927,7 @@ export const colorMixer = {
     },
     CIELabA<CSS extends boolean, R = CSS extends true ? string : CIELabObject>(
         colors: ColorInput[],
-        mode: Mix,
+        mode: MixString,
         css: CSS,
         options: Options
     ): R {

--- a/src/constants/enums-strings.ts
+++ b/src/constants/enums-strings.ts
@@ -1,0 +1,4 @@
+import { Harmony, Mix } from './enums';
+
+export type HarmonyString = `${Harmony}`;
+export type MixString = `${Mix}`;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,6 @@
 export * from './numbers';
 export * from './enums';
+export * from './enums-strings';
 export * from './regexps';
 export * from './errors';
 export * from './options';

--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -1,2 +1,3 @@
 export const MAX_DECIMALS = 6;
 export const DEFAULT_BLEND_STEPS = 5;
+export const DEFAULT_SHADES_TINTS_STEPS = 5;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -16,7 +16,11 @@ import {
     SPACES,
     COLORREGS,
     HSL_HUE,
-    TypeOf
+    TypeOf,
+    Harmony,
+    HarmonyString,
+    Mix,
+    MixString,
 } from '#constants';
 
 //---Has property
@@ -332,4 +336,12 @@ export const getOptionsFromColorInput = (options: InputOptions, ...colors: Color
                     : DEFAULT_OPTIONS.cmykFunction
             )
     };
+};
+
+export const isHarmony = (param: HarmonyString | MixString | InputOptions): param is HarmonyString => {
+    return `${param}` in Harmony;
+};
+
+export const isMix = (param: MixString | InputOptions): param is MixString => {
+    return `${param}` in Mix;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,7 @@ import {
     Mix,
     MixString,
     DEFAULT_BLEND_STEPS,
-    DEFAULT_SHADES_TINTS_STEPS,
-    MAX_DECIMALS
+    DEFAULT_SHADES_TINTS_STEPS
 } from '#constants';
 import {
     rgbToHSL,
@@ -585,7 +584,7 @@ export class ColorTranslator {
         const rgb = getColorReturn<RGBObject>(
             color,
             model,
-            MAX_DECIMALS,
+            options.decimals,
             utils.translateColor.RGB
         );
         return CSS.RGB(rgb, detectedOptions);
@@ -607,7 +606,7 @@ export class ColorTranslator {
         const rgba = getColorReturn<RGBObject>(
             color,
             model,
-            MAX_DECIMALS,
+            options.decimals,
             utils.translateColor.RGBA
         );
         return CSS.RGB(rgba, detectedOptions);
@@ -629,7 +628,7 @@ export class ColorTranslator {
         const hsl = getColorReturn<HSLObject>(
             color,
             model,
-            MAX_DECIMALS,
+            options.decimals,
             utils.translateColor.HSL
         );
         return CSS.HSL(hsl, detectedOptions);
@@ -651,7 +650,7 @@ export class ColorTranslator {
         const hsla = getColorReturn<HSLObject>(
             color,
             model,
-            MAX_DECIMALS,
+            options.decimals,
             utils.translateColor.HSLA
         );
         return CSS.HSL(hsla, detectedOptions);
@@ -673,7 +672,7 @@ export class ColorTranslator {
         const lab = getColorReturn<CIELabObject>(
             color,
             model,
-            MAX_DECIMALS,
+            options.decimals,
             utils.translateColor.CIELab
         );
         return CSS.CIELab(lab, detectedOptions);
@@ -695,7 +694,7 @@ export class ColorTranslator {
         const lab = getColorReturn<CIELabObject>(
             color,
             model,
-            MAX_DECIMALS,
+            options.decimals,
             utils.translateColor.CIELabA
         );
         return CSS.CIELab(lab, detectedOptions);
@@ -717,7 +716,7 @@ export class ColorTranslator {
         const cmyk = getColorReturn<CMYKObject>(
             color,
             model,
-            MAX_DECIMALS,
+            options.decimals,
             utils.translateColor.CMYK
         );
         return CSS.CMYK(cmyk, detectedOptions);
@@ -739,7 +738,7 @@ export class ColorTranslator {
         const cmyka = getColorReturn<CMYKObject>(
             color,
             model,
-            MAX_DECIMALS,
+            options.decimals,
             utils.translateColor.CMYKA
         );
         return CSS.CMYK(cmyka, detectedOptions);

--- a/src/index.ts
+++ b/src/index.ts
@@ -794,14 +794,34 @@ export class ColorTranslator {
     public static getBlendRGBObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): RGBObject[];
+    public static getBlendRGBObject(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): RGBObject[];
+    public static getBlendRGBObject(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): RGBObject[] {
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<RGBObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.RGB
+            );
+        }
         return getBlendReturn<RGBObject>(
             from,
             to,
-            steps,
-            options.decimals,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.RGB
         );
     }
@@ -809,20 +829,46 @@ export class ColorTranslator {
     public static getBlendRGB(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string[];
+    public static getBlendRGB(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): string[];
+    public static getBlendRGB(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): string[] {
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<RGBObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.RGB
+            )
+                .map((color: RGBObject): string => {
+                    return CSS.RGB(
+                        color,
+                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                    );
+                });
+        }
         return getBlendReturn<RGBObject>(
             from,
             to,
-            steps,
-            MAX_DECIMALS,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.RGB
         )
             .map((color: RGBObject): string => {
                 return CSS.RGB(
                     color,
-                    getOptionsFromColorInput(options, from, to)
+                    getOptionsFromColorInput(thirdParameter || {}, from, to)
                 );
             });
     }
@@ -830,14 +876,34 @@ export class ColorTranslator {
     public static getBlendRGBAObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): RGBObject[];
+    public static getBlendRGBAObject(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): RGBObject[];
+    public static getBlendRGBAObject(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): RGBObject[] {
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<RGBObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.RGBA
+            );
+        }
         return getBlendReturn<RGBObject>(
             from,
             to,
-            steps,
-            options.decimals,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.RGBA
         );
     }
@@ -845,20 +911,46 @@ export class ColorTranslator {
     public static getBlendRGBA(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string[];
+    public static getBlendRGBA(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): string[];
+    public static getBlendRGBA(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): string[] {
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<RGBObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.RGBA
+            )
+                .map((color: RGBObject): string => {
+                    return CSS.RGB(
+                        color,
+                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                    );
+                });
+        }
         return getBlendReturn<RGBObject>(
             from,
             to,
-            steps,
-            MAX_DECIMALS,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.RGBA
         )
             .map((color: RGBObject): string => {
                 return CSS.RGB(
                     color,
-                    getOptionsFromColorInput(options, from, to)
+                    getOptionsFromColorInput(thirdParameter || {}, from, to)
                 );
             });
     }
@@ -866,14 +958,34 @@ export class ColorTranslator {
     public static getBlendHSLObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): HSLObject[];
+    public static getBlendHSLObject(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): HSLObject[];
+    public static getBlendHSLObject(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): HSLObject[] {
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<HSLObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.HSL
+            );
+        }
         return getBlendReturn<HSLObject>(
             from,
             to,
-            steps,
-            options.decimals,
+            DEFAULT_BLEND_STEPS,
+            fourthParameter?.decimals,
             utils.translateColor.HSL
         );
     }
@@ -881,33 +993,81 @@ export class ColorTranslator {
     public static getBlendHSL(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string[];
+    public static getBlendHSL(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): string[];
+    public static getBlendHSL(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): string[] {
-        const detectedOptions = getOptionsFromColorInput(options, from, to);
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<HSLObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.HSL
+            )
+                .map((color: HSLObject) => {
+                    return CSS.HSL(
+                        color,
+                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                    );
+                });
+        }
         return getBlendReturn<HSLObject>(
             from,
             to,
-            steps,
-            MAX_DECIMALS,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.HSL
         )
             .map((color: HSLObject) => {
-                return CSS.HSL(color, detectedOptions);
+                return CSS.HSL(
+                    color,
+                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                );
             });
     }
 
     public static getBlendHSLAObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): HSLObject[];
+    public static getBlendHSLAObject(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): HSLObject[];
+    public static getBlendHSLAObject(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): HSLObject[] {
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<HSLObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.HSLA
+            );
+        }
         return getBlendReturn<HSLObject>(
             from,
             to,
-            steps,
-            options.decimals,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.HSLA
         );
     }
@@ -915,33 +1075,81 @@ export class ColorTranslator {
     public static getBlendHSLA(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string[];
+    public static getBlendHSLA(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): string[];
+    public static getBlendHSLA(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): string[] {
-        const detectedOptions = getOptionsFromColorInput(options, from, to);
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<HSLObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.HSLA
+            )
+                .map((color: HSLObject): string => {
+                    return CSS.HSL(
+                        color,
+                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                    );
+                });
+        }
         return getBlendReturn<HSLObject>(
             from,
             to,
-            steps,
-            MAX_DECIMALS,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.HSLA
         )
             .map((color: HSLObject): string => {
-                return CSS.HSL(color, detectedOptions);
+                return CSS.HSL(
+                    color,
+                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                );
             });
     }
 
     public static getBlendCIELabObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): CIELabObject[];
+    public static getBlendCIELabObject(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): CIELabObject[];
+    public static getBlendCIELabObject(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): CIELabObject[] {
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<CIELabObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.CIELab
+            );
+        }
         return getBlendReturn<CIELabObject>(
             from,
             to,
-            steps,
-            options.decimals,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.CIELab
         );
     }
@@ -949,33 +1157,81 @@ export class ColorTranslator {
     public static getBlendCIELab(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string[];
+    public static getBlendCIELab(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): string[];
+    public static getBlendCIELab(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): string[] {
-        const detectedOptions = getOptionsFromColorInput(options, from, to);
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<CIELabObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.CIELab
+            )
+                .map((color: CIELabObject) => {
+                    return CSS.CIELab(
+                        color,
+                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                    );
+                });
+        }
         return getBlendReturn<CIELabObject>(
             from,
             to,
-            steps,
-            MAX_DECIMALS,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.CIELab
         )
             .map((color: CIELabObject) => {
-                return CSS.CIELab(color, detectedOptions);
+                return CSS.CIELab(
+                    color,
+                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                );
             });
     }
 
     public static getBlendCIELabAObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): CIELabObject[];
+    public static getBlendCIELabAObject(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): CIELabObject[];
+    public static getBlendCIELabAObject(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): CIELabObject[] {
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<CIELabObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.CIELabA
+            );
+        }
         return getBlendReturn<CIELabObject>(
             from,
             to,
-            steps,
-            options.decimals,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.CIELabA
         );
     }
@@ -983,19 +1239,47 @@ export class ColorTranslator {
     public static getBlendCIELabA(
         from: ColorInput,
         to: ColorInput,
-        steps: number = DEFAULT_BLEND_STEPS,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string[];
+    public static getBlendCIELabA(
+        from: ColorInput,
+        to: ColorInput,
+        steps?: number,
+        options?: InputOptions
+    ): string[];
+    public static getBlendCIELabA(
+        from: ColorInput,
+        to: ColorInput,
+        thirdParameter?: number | InputOptions,
+        fourthParameter?: InputOptions
     ): string[] {
-        const detectedOptions = getOptionsFromColorInput(options, from, to);
+        if (typeof thirdParameter === 'number') {
+            return getBlendReturn<CIELabObject>(
+                from,
+                to,
+                thirdParameter,
+                fourthParameter?.decimals,
+                utils.translateColor.CIELabA
+            )
+                .map((color: CIELabObject) => {
+                    return CSS.CIELab(
+                        color,
+                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                    );
+                });
+        }
         return getBlendReturn<CIELabObject>(
             from,
             to,
-            steps,
-            MAX_DECIMALS,
+            DEFAULT_BLEND_STEPS,
+            thirdParameter?.decimals,
             utils.translateColor.CIELabA
         )
             .map((color: CIELabObject) => {
-                return CSS.CIELab(color, detectedOptions);
+                return CSS.CIELab(
+                    color,
+                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                );
             });
     }
 
@@ -1018,157 +1302,433 @@ export class ColorTranslator {
 
     public static getMixRGBObject(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): RGBObject;
+    public static getMixRGBObject(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): RGBObject;
+    public static getMixRGBObject(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): RGBObject {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.RGB(
+                colors,
+                secondParameter,
+                false,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.RGB(
             colors,
-            mode,
+            Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixRGB(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string;
+    public static getMixRGB(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): string;
+    public static getMixRGB(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): string {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.RGB(
+                colors,
+                secondParameter,
+                true,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.RGB(
             colors,
-            mode,
+            Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixRGBAObject(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): RGBObject;
+    public static getMixRGBAObject(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): RGBObject;
+    public static getMixRGBAObject(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): RGBObject {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.RGBA(
+                colors,
+                secondParameter,
+                false,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.RGBA(
             colors,
-            mode,
+            Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixRGBA(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string;
+    public static getMixRGBA(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): string;
+    public static getMixRGBA(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): string {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.RGBA(
+                colors,
+                secondParameter,
+                true,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.RGBA(
             colors,
-            mode,
+            Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixHSLObject(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): HSLObject;
+    public static getMixHSLObject(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): HSLObject;
+    public static getMixHSLObject(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): HSLObject {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.HSL(
+                colors,
+                secondParameter,
+                false,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.HSL(
             colors,
-            mode,
+            Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixHSL(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string;
+    public static getMixHSL(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): string;
+    public static getMixHSL(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): string {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.HSL(
+                colors,
+                secondParameter,
+                true,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.HSL(
             colors,
-            mode,
+            Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixHSLAObject(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): HSLObject;
+    public static getMixHSLAObject(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): HSLObject;
+    public static getMixHSLAObject(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): HSLObject {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.HSLA(
+                colors,
+                secondParameter,
+                false,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.HSLA(
             colors,
-            mode,
+            Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixHSLA(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string;
+    public static getMixHSLA(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): string;
+    public static getMixHSLA(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): string {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.HSLA(
+                colors,
+                secondParameter,
+                true,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.HSLA(
             colors,
-            mode,
+            Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixCIELabObject(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): CIELabObject;
+    public static getMixCIELabObject(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): CIELabObject;
+    public static getMixCIELabObject(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): CIELabObject {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.CIELab(
+                colors,
+                secondParameter,
+                false,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.CIELab(
             colors,
-            mode,
+            Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixCIELab(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string;
+    public static getMixCIELab(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): string;
+    public static getMixCIELab(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): string {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.CIELab(
+                colors,
+                secondParameter,
+                true,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.CIELab(
             colors,
-            mode,
+            Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixCIELabAObject(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): CIELabObject;
+    public static getMixCIELabAObject(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): CIELabObject;
+    public static getMixCIELabAObject(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): CIELabObject {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.CIELabA(
+                colors,
+                secondParameter,
+                false,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.CIELabA(
             colors,
-            mode,
+            Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 
     public static getMixCIELabA(
         colors: ColorInput[],
-        mode: MixString = Mix.ADDITIVE,
-        options: InputOptions = {}
+        options?: InputOptions
+    ): string;
+    public static getMixCIELabA(
+        colors: ColorInput[],
+        mode?: MixString,
+        options?: InputOptions
+    ): string;
+    public static getMixCIELabA(
+        colors: ColorInput[],
+        secondParameter?: MixString | InputOptions,
+        thirdParameter?: InputOptions
     ): string {
+        if (typeof secondParameter === 'string') {
+            return utils.colorMixer.CIELabA(
+                colors,
+                secondParameter,
+                true,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    ...colors
+                )
+            );
+        }
         return utils.colorMixer.CIELabA(
             colors,
-            mode,
+            Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(options, ...colors)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                ...colors
+            )
         );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
     Mix,
     MixString,
     DEFAULT_BLEND_STEPS,
+    DEFAULT_SHADES_TINTS_STEPS,
     MAX_DECIMALS
 } from '#constants';
 import {
@@ -799,7 +800,7 @@ export class ColorTranslator {
     public static getBlendRGBObject(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): RGBObject[];
     public static getBlendRGBObject(
@@ -834,7 +835,7 @@ export class ColorTranslator {
     public static getBlendRGB(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): string[];
     public static getBlendRGB(
@@ -881,7 +882,7 @@ export class ColorTranslator {
     public static getBlendRGBAObject(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): RGBObject[];
     public static getBlendRGBAObject(
@@ -916,7 +917,7 @@ export class ColorTranslator {
     public static getBlendRGBA(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): string[];
     public static getBlendRGBA(
@@ -963,7 +964,7 @@ export class ColorTranslator {
     public static getBlendHSLObject(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): HSLObject[];
     public static getBlendHSLObject(
@@ -998,7 +999,7 @@ export class ColorTranslator {
     public static getBlendHSL(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): string[];
     public static getBlendHSL(
@@ -1045,7 +1046,7 @@ export class ColorTranslator {
     public static getBlendHSLAObject(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): HSLObject[];
     public static getBlendHSLAObject(
@@ -1080,7 +1081,7 @@ export class ColorTranslator {
     public static getBlendHSLA(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): string[];
     public static getBlendHSLA(
@@ -1127,7 +1128,7 @@ export class ColorTranslator {
     public static getBlendCIELabObject(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): CIELabObject[];
     public static getBlendCIELabObject(
@@ -1162,7 +1163,7 @@ export class ColorTranslator {
     public static getBlendCIELab(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): string[];
     public static getBlendCIELab(
@@ -1209,7 +1210,7 @@ export class ColorTranslator {
     public static getBlendCIELabAObject(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): CIELabObject[];
     public static getBlendCIELabAObject(
@@ -1244,7 +1245,7 @@ export class ColorTranslator {
     public static getBlendCIELabA(
         from: ColorInput,
         to: ColorInput,
-        steps?: number,
+        steps: number,
         options?: InputOptions
     ): string[];
     public static getBlendCIELabA(
@@ -1306,7 +1307,7 @@ export class ColorTranslator {
     ): RGBObject;
     public static getMixRGBObject(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): RGBObject;
     public static getMixRGBObject(
@@ -1342,7 +1343,7 @@ export class ColorTranslator {
     ): string;
     public static getMixRGB(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): string;
     public static getMixRGB(
@@ -1378,7 +1379,7 @@ export class ColorTranslator {
     ): RGBObject;
     public static getMixRGBAObject(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): RGBObject;
     public static getMixRGBAObject(
@@ -1414,7 +1415,7 @@ export class ColorTranslator {
     ): string;
     public static getMixRGBA(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): string;
     public static getMixRGBA(
@@ -1450,7 +1451,7 @@ export class ColorTranslator {
     ): HSLObject;
     public static getMixHSLObject(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): HSLObject;
     public static getMixHSLObject(
@@ -1486,7 +1487,7 @@ export class ColorTranslator {
     ): string;
     public static getMixHSL(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): string;
     public static getMixHSL(
@@ -1522,7 +1523,7 @@ export class ColorTranslator {
     ): HSLObject;
     public static getMixHSLAObject(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): HSLObject;
     public static getMixHSLAObject(
@@ -1558,7 +1559,7 @@ export class ColorTranslator {
     ): string;
     public static getMixHSLA(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): string;
     public static getMixHSLA(
@@ -1594,7 +1595,7 @@ export class ColorTranslator {
     ): CIELabObject;
     public static getMixCIELabObject(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): CIELabObject;
     public static getMixCIELabObject(
@@ -1630,7 +1631,7 @@ export class ColorTranslator {
     ): string;
     public static getMixCIELab(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): string;
     public static getMixCIELab(
@@ -1666,7 +1667,7 @@ export class ColorTranslator {
     ): CIELabObject;
     public static getMixCIELabAObject(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): CIELabObject;
     public static getMixCIELabAObject(
@@ -1702,7 +1703,7 @@ export class ColorTranslator {
     ): string;
     public static getMixCIELabA(
         colors: ColorInput[],
-        mode?: MixString,
+        mode: MixString,
         options?: InputOptions
     ): string;
     public static getMixCIELabA(
@@ -1733,59 +1734,109 @@ export class ColorTranslator {
     }
 
     // Get shades static method
+    public static getShades(color: string, options?: InputOptions): string[];
+    public static getShades(color: HEXObject, options?: InputOptions): HEXObject[];
+    public static getShades(color: RGBObject, options?: InputOptions): RGBObject[];
+    public static getShades(color: HSLObjectGeneric, options?: InputOptions): HSLObject[];
+    public static getShades(color: CIELabObjectGeneric, options?: InputOptions): CIELabObject[];
+
     public static getShades(color: string, shades: number, options?: InputOptions): string[];
     public static getShades(color: HEXObject, shades: number, options?: InputOptions): HEXObject[];
     public static getShades(color: RGBObject, shades: number, options?: InputOptions): RGBObject[];
     public static getShades(color: HSLObjectGeneric, shades: number, options?: InputOptions): HSLObject[];
     public static getShades(color: CIELabObjectGeneric, shades: number, options?: InputOptions): CIELabObject[];
-    public static getShades(color: ColorInputWithoutCMYK, shades: number, options = {}): ColorOutput[] {
+
+    public static getShades(
+        color: ColorInputWithoutCMYK,
+        secondParameter?: number | InputOptions,
+        thirdParameter?: InputOptions
+    ): ColorOutput[] {
+        if (typeof secondParameter === 'number') {
+            return utils.getColorMixture(
+                color,
+                secondParameter,
+                true,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    color
+                )
+            );
+        }
         return utils.getColorMixture(
             color,
-            shades,
+            DEFAULT_SHADES_TINTS_STEPS,
             true,
-            getOptionsFromColorInput(options, color)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                color
+            )
         );
     }
 
     // Get tints static method
+    public static getTints(color: string, options?: InputOptions): string[];
+    public static getTints(color: HEXObject, options?: InputOptions): HEXObject[];
+    public static getTints(color: RGBObject, options?: InputOptions): RGBObject[];
+    public static getTints(color: HSLObjectGeneric, options?: InputOptions): HSLObject[];
+    public static getTints(color: CIELabObjectGeneric, options?: InputOptions): CIELabObject[];
+
     public static getTints(color: string, tints: number, options?: InputOptions): string[];
     public static getTints(color: HEXObject, tints: number, options?: InputOptions): HEXObject[];
     public static getTints(color: RGBObject, tints: number, options?: InputOptions): RGBObject[];
     public static getTints(color: HSLObjectGeneric, tints: number, options?: InputOptions): HSLObject[];
     public static getTints(color: CIELabObjectGeneric, tints: number, options?: InputOptions): CIELabObject[];
-    public static getTints(color: ColorInputWithoutCMYK, tints: number, options = {}): ColorOutput[] {
+
+    public static getTints(
+        color: ColorInputWithoutCMYK,
+        secondParameter?: number | InputOptions,
+        thirdParameter?: InputOptions
+    ): ColorOutput[] {
+        if (typeof secondParameter === 'number') {
+            return utils.getColorMixture(
+                color,
+                secondParameter,
+                false,
+                getOptionsFromColorInput(
+                    thirdParameter || {},
+                    color
+                )
+            );
+        }
         return utils.getColorMixture(
             color,
-            tints,
+            DEFAULT_SHADES_TINTS_STEPS,
             false,
-            getOptionsFromColorInput(options, color)
+            getOptionsFromColorInput(
+                secondParameter || {},
+                color
+            )
         );
     }
 
     // Color Harmony Static Method
-    public static getHarmony(color: string, harmony?: Harmony, mode?: MixString, options?: InputOptions): string[];
-    public static getHarmony(color: HEXObject, harmony?: Harmony, mode?: MixString, options?: InputOptions): HEXObject[];
-    public static getHarmony(color: RGBObject, harmony?: Harmony, mode?: MixString, options?: InputOptions): RGBObject[];
-    public static getHarmony(color: HSLObjectGeneric, harmony?: Harmony, mode?: MixString, options?: InputOptions): HSLObject[];
-    public static getHarmony(color: CIELabObjectGeneric, harmony?: Harmony, mode?: MixString, options?: InputOptions): CIELabObject[];
-
-    public static getHarmony(color: string, harmony?: Harmony, options?: InputOptions): string[];
-    public static getHarmony(color: HEXObject, harmony?: Harmony, options?: InputOptions): HEXObject[];
-    public static getHarmony(color: RGBObject, harmony?: Harmony, options?: InputOptions): RGBObject[];
-    public static getHarmony(color: HSLObjectGeneric, harmony?: Harmony, options?: InputOptions): HSLObject[];
-    public static getHarmony(color: CIELabObjectGeneric, harmony?: Harmony, options?: InputOptions): CIELabObject[];
-
-    public static getHarmony(color: string, mode?: MixString, options?: InputOptions): string[];
-    public static getHarmony(color: HEXObject, mode?: MixString, options?: InputOptions): HEXObject[];
-    public static getHarmony(color: RGBObject, mode?: MixString, options?: InputOptions): RGBObject[];
-    public static getHarmony(color: HSLObjectGeneric, mode?: MixString, options?: InputOptions): HSLObject[];
-    public static getHarmony(color: CIELabObjectGeneric, mode?: MixString, options?: InputOptions): CIELabObject[];
-
     public static getHarmony(color: string, options?: InputOptions): string[];
     public static getHarmony(color: HEXObject, options?: InputOptions): HEXObject[];
     public static getHarmony(color: RGBObject, options?: InputOptions): RGBObject[];
     public static getHarmony(color: HSLObjectGeneric, options?: InputOptions): HSLObject[];
     public static getHarmony(color: CIELabObjectGeneric, options?: InputOptions): CIELabObject[];
+
+    public static getHarmony(color: string, mode: MixString, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, mode: MixString, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, mode: MixString, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, mode: MixString, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, mode: MixString, options?: InputOptions): CIELabObject[];
+
+    public static getHarmony(color: string, harmony: Harmony, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, harmony: Harmony, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, harmony: Harmony, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, harmony: Harmony, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, harmony: Harmony, options?: InputOptions): CIELabObject[];
+
+    public static getHarmony(color: string, harmony?: Harmony, mode?: MixString, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, harmony?: Harmony, mode?: MixString, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, harmony?: Harmony, mode?: MixString, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, harmony?: Harmony, mode?: MixString, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, harmony?: Harmony, mode?: MixString, options?: InputOptions): CIELabObject[];
 
     public static getHarmony(
         color: ColorInputWithoutCMYK,

--- a/src/index.ts
+++ b/src/index.ts
@@ -800,7 +800,7 @@ export class ColorTranslator {
     public static getBlendRGBObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): RGBObject[];
     public static getBlendRGBObject(
@@ -835,7 +835,7 @@ export class ColorTranslator {
     public static getBlendRGB(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): string[];
     public static getBlendRGB(
@@ -882,7 +882,7 @@ export class ColorTranslator {
     public static getBlendRGBAObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): RGBObject[];
     public static getBlendRGBAObject(
@@ -917,7 +917,7 @@ export class ColorTranslator {
     public static getBlendRGBA(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): string[];
     public static getBlendRGBA(
@@ -964,7 +964,7 @@ export class ColorTranslator {
     public static getBlendHSLObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): HSLObject[];
     public static getBlendHSLObject(
@@ -999,7 +999,7 @@ export class ColorTranslator {
     public static getBlendHSL(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): string[];
     public static getBlendHSL(
@@ -1046,7 +1046,7 @@ export class ColorTranslator {
     public static getBlendHSLAObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): HSLObject[];
     public static getBlendHSLAObject(
@@ -1081,7 +1081,7 @@ export class ColorTranslator {
     public static getBlendHSLA(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): string[];
     public static getBlendHSLA(
@@ -1128,7 +1128,7 @@ export class ColorTranslator {
     public static getBlendCIELabObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): CIELabObject[];
     public static getBlendCIELabObject(
@@ -1163,7 +1163,7 @@ export class ColorTranslator {
     public static getBlendCIELab(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): string[];
     public static getBlendCIELab(
@@ -1210,7 +1210,7 @@ export class ColorTranslator {
     public static getBlendCIELabAObject(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): CIELabObject[];
     public static getBlendCIELabAObject(
@@ -1245,7 +1245,7 @@ export class ColorTranslator {
     public static getBlendCIELabA(
         from: ColorInput,
         to: ColorInput,
-        steps: number,
+        steps?: number,
         options?: InputOptions
     ): string[];
     public static getBlendCIELabA(
@@ -1307,7 +1307,7 @@ export class ColorTranslator {
     ): RGBObject;
     public static getMixRGBObject(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): RGBObject;
     public static getMixRGBObject(
@@ -1343,7 +1343,7 @@ export class ColorTranslator {
     ): string;
     public static getMixRGB(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): string;
     public static getMixRGB(
@@ -1379,7 +1379,7 @@ export class ColorTranslator {
     ): RGBObject;
     public static getMixRGBAObject(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): RGBObject;
     public static getMixRGBAObject(
@@ -1415,7 +1415,7 @@ export class ColorTranslator {
     ): string;
     public static getMixRGBA(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): string;
     public static getMixRGBA(
@@ -1451,7 +1451,7 @@ export class ColorTranslator {
     ): HSLObject;
     public static getMixHSLObject(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): HSLObject;
     public static getMixHSLObject(
@@ -1487,7 +1487,7 @@ export class ColorTranslator {
     ): string;
     public static getMixHSL(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): string;
     public static getMixHSL(
@@ -1523,7 +1523,7 @@ export class ColorTranslator {
     ): HSLObject;
     public static getMixHSLAObject(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): HSLObject;
     public static getMixHSLAObject(
@@ -1559,7 +1559,7 @@ export class ColorTranslator {
     ): string;
     public static getMixHSLA(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): string;
     public static getMixHSLA(
@@ -1595,7 +1595,7 @@ export class ColorTranslator {
     ): CIELabObject;
     public static getMixCIELabObject(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): CIELabObject;
     public static getMixCIELabObject(
@@ -1631,7 +1631,7 @@ export class ColorTranslator {
     ): string;
     public static getMixCIELab(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): string;
     public static getMixCIELab(
@@ -1667,7 +1667,7 @@ export class ColorTranslator {
     ): CIELabObject;
     public static getMixCIELabAObject(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): CIELabObject;
     public static getMixCIELabAObject(
@@ -1703,7 +1703,7 @@ export class ColorTranslator {
     ): string;
     public static getMixCIELabA(
         colors: ColorInput[],
-        mode: MixString,
+        mode?: MixString,
         options?: InputOptions
     ): string;
     public static getMixCIELabA(
@@ -1740,11 +1740,11 @@ export class ColorTranslator {
     public static getShades(color: HSLObjectGeneric, options?: InputOptions): HSLObject[];
     public static getShades(color: CIELabObjectGeneric, options?: InputOptions): CIELabObject[];
 
-    public static getShades(color: string, shades: number, options?: InputOptions): string[];
-    public static getShades(color: HEXObject, shades: number, options?: InputOptions): HEXObject[];
-    public static getShades(color: RGBObject, shades: number, options?: InputOptions): RGBObject[];
-    public static getShades(color: HSLObjectGeneric, shades: number, options?: InputOptions): HSLObject[];
-    public static getShades(color: CIELabObjectGeneric, shades: number, options?: InputOptions): CIELabObject[];
+    public static getShades(color: string, shades?: number, options?: InputOptions): string[];
+    public static getShades(color: HEXObject, shades?: number, options?: InputOptions): HEXObject[];
+    public static getShades(color: RGBObject, shades?: number, options?: InputOptions): RGBObject[];
+    public static getShades(color: HSLObjectGeneric, shades?: number, options?: InputOptions): HSLObject[];
+    public static getShades(color: CIELabObjectGeneric, shades?: number, options?: InputOptions): CIELabObject[];
 
     public static getShades(
         color: ColorInputWithoutCMYK,
@@ -1780,11 +1780,11 @@ export class ColorTranslator {
     public static getTints(color: HSLObjectGeneric, options?: InputOptions): HSLObject[];
     public static getTints(color: CIELabObjectGeneric, options?: InputOptions): CIELabObject[];
 
-    public static getTints(color: string, tints: number, options?: InputOptions): string[];
-    public static getTints(color: HEXObject, tints: number, options?: InputOptions): HEXObject[];
-    public static getTints(color: RGBObject, tints: number, options?: InputOptions): RGBObject[];
-    public static getTints(color: HSLObjectGeneric, tints: number, options?: InputOptions): HSLObject[];
-    public static getTints(color: CIELabObjectGeneric, tints: number, options?: InputOptions): CIELabObject[];
+    public static getTints(color: string, tints?: number, options?: InputOptions): string[];
+    public static getTints(color: HEXObject, tints?: number, options?: InputOptions): HEXObject[];
+    public static getTints(color: RGBObject, tints?: number, options?: InputOptions): RGBObject[];
+    public static getTints(color: HSLObjectGeneric, tints?: number, options?: InputOptions): HSLObject[];
+    public static getTints(color: CIELabObjectGeneric, tints?: number, options?: InputOptions): CIELabObject[];
 
     public static getTints(
         color: ColorInputWithoutCMYK,
@@ -1820,17 +1820,17 @@ export class ColorTranslator {
     public static getHarmony(color: HSLObjectGeneric, options?: InputOptions): HSLObject[];
     public static getHarmony(color: CIELabObjectGeneric, options?: InputOptions): CIELabObject[];
 
-    public static getHarmony(color: string, mode: MixString, options?: InputOptions): string[];
-    public static getHarmony(color: HEXObject, mode: MixString, options?: InputOptions): HEXObject[];
-    public static getHarmony(color: RGBObject, mode: MixString, options?: InputOptions): RGBObject[];
-    public static getHarmony(color: HSLObjectGeneric, mode: MixString, options?: InputOptions): HSLObject[];
-    public static getHarmony(color: CIELabObjectGeneric, mode: MixString, options?: InputOptions): CIELabObject[];
+    public static getHarmony(color: string, mode?: MixString, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, mode?: MixString, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, mode?: MixString, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, mode?: MixString, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, mode?: MixString, options?: InputOptions): CIELabObject[];
 
-    public static getHarmony(color: string, harmony: Harmony, options?: InputOptions): string[];
-    public static getHarmony(color: HEXObject, harmony: Harmony, options?: InputOptions): HEXObject[];
-    public static getHarmony(color: RGBObject, harmony: Harmony, options?: InputOptions): RGBObject[];
-    public static getHarmony(color: HSLObjectGeneric, harmony: Harmony, options?: InputOptions): HSLObject[];
-    public static getHarmony(color: CIELabObjectGeneric, harmony: Harmony, options?: InputOptions): CIELabObject[];
+    public static getHarmony(color: string, harmony?: Harmony, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, harmony?: Harmony, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, harmony?: Harmony, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, harmony?: Harmony, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, harmony?: Harmony, options?: InputOptions): CIELabObject[];
 
     public static getHarmony(color: string, harmony?: Harmony, mode?: MixString, options?: InputOptions): string[];
     public static getHarmony(color: HEXObject, harmony?: Harmony, mode?: MixString, options?: InputOptions): HEXObject[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1837,5 +1837,6 @@ export {
     HEXObject,
     RGBObject,
     HSLObject,
+    CIELabObject,
     CMYKObject
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,9 @@ import {
 import {
     ColorModel,
     Harmony,
+    HarmonyString,
     Mix,
+    MixString,
     DEFAULT_BLEND_STEPS,
     MAX_DECIMALS
 } from '#constants';
@@ -34,7 +36,9 @@ import {
     round,
     minmax,
     getOptionsFromColorInput,
-    normalizeHue
+    normalizeHue,
+    isHarmony,
+    isMix
 } from '#helpers';
 
 const getColorReturn = <T>(
@@ -64,9 +68,9 @@ const getBlendReturn = <T>(
 };
 
 const getHarmonyReturn = (
-    harmony: Harmony,
+    harmony: HarmonyString,
     color: ColorInputWithoutCMYK,
-    mode: Mix,
+    mode: MixString,
     options: Options,
 ): ColorOutput[] => {
     return ({
@@ -996,25 +1000,25 @@ export class ColorTranslator {
     }
 
     // Color Mix Static Methods
-    public static getMixHEXObject(colors: ColorInput[], mode: Mix = Mix.ADDITIVE): HEXObject {
+    public static getMixHEXObject(colors: ColorInput[], mode: MixString = Mix.ADDITIVE): HEXObject {
         return utils.colorMixer.HEX(colors, mode, false);
     }
 
-    public static getMixHEX(colors: ColorInput[], mode: Mix = Mix.ADDITIVE): string {
+    public static getMixHEX(colors: ColorInput[], mode: MixString = Mix.ADDITIVE): string {
         return utils.colorMixer.HEX(colors, mode, true);
     }
 
-    public static getMixHEXAObject(colors: ColorInput[], mode: Mix = Mix.ADDITIVE): HEXObject {
+    public static getMixHEXAObject(colors: ColorInput[], mode: MixString = Mix.ADDITIVE): HEXObject {
         return utils.colorMixer.HEXA(colors, mode, false);
     }
 
-    public static getMixHEXA(colors: ColorInput[], mode: Mix = Mix.ADDITIVE): string {
+    public static getMixHEXA(colors: ColorInput[], mode: MixString = Mix.ADDITIVE): string {
         return utils.colorMixer.HEXA(colors, mode, true);
     }
 
     public static getMixRGBObject(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): RGBObject {
         return utils.colorMixer.RGB(
@@ -1027,7 +1031,7 @@ export class ColorTranslator {
 
     public static getMixRGB(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): string {
         return utils.colorMixer.RGB(
@@ -1040,7 +1044,7 @@ export class ColorTranslator {
 
     public static getMixRGBAObject(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): RGBObject {
         return utils.colorMixer.RGBA(
@@ -1053,7 +1057,7 @@ export class ColorTranslator {
 
     public static getMixRGBA(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): string {
         return utils.colorMixer.RGBA(
@@ -1066,7 +1070,7 @@ export class ColorTranslator {
 
     public static getMixHSLObject(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): HSLObject {
         return utils.colorMixer.HSL(
@@ -1079,7 +1083,7 @@ export class ColorTranslator {
 
     public static getMixHSL(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): string {
         return utils.colorMixer.HSL(
@@ -1092,7 +1096,7 @@ export class ColorTranslator {
 
     public static getMixHSLAObject(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): HSLObject {
         return utils.colorMixer.HSLA(
@@ -1105,7 +1109,7 @@ export class ColorTranslator {
 
     public static getMixHSLA(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): string {
         return utils.colorMixer.HSLA(
@@ -1118,7 +1122,7 @@ export class ColorTranslator {
 
     public static getMixCIELabObject(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): CIELabObject {
         return utils.colorMixer.CIELab(
@@ -1131,7 +1135,7 @@ export class ColorTranslator {
 
     public static getMixCIELab(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): string {
         return utils.colorMixer.CIELab(
@@ -1144,7 +1148,7 @@ export class ColorTranslator {
 
     public static getMixCIELabAObject(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): CIELabObject {
         return utils.colorMixer.CIELabA(
@@ -1157,7 +1161,7 @@ export class ColorTranslator {
 
     public static getMixCIELabA(
         colors: ColorInput[],
-        mode: Mix = Mix.ADDITIVE,
+        mode: MixString = Mix.ADDITIVE,
         options: InputOptions = {}
     ): string {
         return utils.colorMixer.CIELabA(
@@ -1199,17 +1203,69 @@ export class ColorTranslator {
     }
 
     // Color Harmony Static Method
-    public static getHarmony(color: string, harmony?: Harmony, mode?: Mix, options?: InputOptions): string[];
-    public static getHarmony(color: HEXObject, harmony?: Harmony, mode?: Mix, options?: InputOptions): HEXObject[];
-    public static getHarmony(color: RGBObject, harmony?: Harmony, mode?: Mix, options?: InputOptions): RGBObject[];
-    public static getHarmony(color: HSLObjectGeneric, harmony?: Harmony, mode?: Mix, options?: InputOptions): HSLObject[];
-    public static getHarmony(color: CIELabObjectGeneric, harmony?: Harmony, mode?: Mix, options?: InputOptions): CIELabObject[];
-    public static getHarmony(color: ColorInputWithoutCMYK, harmony: Harmony = Harmony.COMPLEMENTARY, mode: Mix = Mix.ADDITIVE, options = {}): ColorOutput[] {
+    public static getHarmony(color: string, harmony?: Harmony, mode?: MixString, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, harmony?: Harmony, mode?: MixString, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, harmony?: Harmony, mode?: MixString, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, harmony?: Harmony, mode?: MixString, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, harmony?: Harmony, mode?: MixString, options?: InputOptions): CIELabObject[];
+
+    public static getHarmony(color: string, harmony?: Harmony, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, harmony?: Harmony, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, harmony?: Harmony, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, harmony?: Harmony, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, harmony?: Harmony, options?: InputOptions): CIELabObject[];
+
+    public static getHarmony(color: string, mode?: MixString, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, mode?: MixString, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, mode?: MixString, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, mode?: MixString, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, mode?: MixString, options?: InputOptions): CIELabObject[];
+
+    public static getHarmony(color: string, options?: InputOptions): string[];
+    public static getHarmony(color: HEXObject, options?: InputOptions): HEXObject[];
+    public static getHarmony(color: RGBObject, options?: InputOptions): RGBObject[];
+    public static getHarmony(color: HSLObjectGeneric, options?: InputOptions): HSLObject[];
+    public static getHarmony(color: CIELabObjectGeneric, options?: InputOptions): CIELabObject[];
+
+    public static getHarmony(
+        color: ColorInputWithoutCMYK,
+        secondParam?: HarmonyString | MixString | InputOptions,
+        thirdParam?: MixString | InputOptions,
+        fourthParam?: InputOptions
+    ): ColorOutput[] {
+        if (isHarmony(secondParam)) {
+            return getHarmonyReturn(
+                secondParam,
+                color,
+                isMix(thirdParam)
+                    ? thirdParam
+                    : Mix.ADDITIVE,
+                getOptionsFromColorInput(
+                    isMix(thirdParam)
+                        ? (fourthParam || {})
+                        : thirdParam || {},
+                    color
+                )
+            );
+        } else if (isMix(secondParam)) {
+            return getHarmonyReturn(
+                Harmony.COMPLEMENTARY,
+                color,
+                secondParam,
+                getOptionsFromColorInput(
+                    thirdParam as InputOptions || {},
+                    color
+                )
+            );
+        }
         return getHarmonyReturn(
-            harmony,
+            Harmony.COMPLEMENTARY,
             color,
-            mode,
-            getOptionsFromColorInput(options, color)
+            Mix.ADDITIVE,
+            getOptionsFromColorInput(
+                secondParam || {},
+                color
+            )
         );
     }
 }

--- a/tests/__snapshots__/blending.test.ts.snap
+++ b/tests/__snapshots__/blending.test.ts.snap
@@ -85,6 +85,65 @@ exports[`ColorTranslator blending tests Blending with L*a*b colors 4`] = `
 ]
 `;
 
+exports[`ColorTranslator blending tests Blending with L*a*b colors 5`] = `
+[
+  "lab(54.291734 80.812455 69.88504)",
+  "lab(29.563244 55.959822 -36.18907)",
+  "lab(29.567573 68.298653 -112.02943)",
+]
+`;
+
+exports[`ColorTranslator blending tests Blending with L*a*b colors 6`] = `
+[
+  "lab(54.291734 80.812455 69.88504 / 1)",
+  "lab(29.563244 55.959822 -36.18907 / 1)",
+  "lab(29.567573 68.298653 -112.02943 / 1)",
+]
+`;
+
+exports[`ColorTranslator blending tests Blending with L*a*b colors 7`] = `
+[
+  {
+    "L": 54.291734,
+    "a": 80.812455,
+    "b": 69.88504,
+  },
+  {
+    "L": 29.563244,
+    "a": 55.959822,
+    "b": -36.18907,
+  },
+  {
+    "L": 29.567573,
+    "a": 68.298653,
+    "b": -112.02943,
+  },
+]
+`;
+
+exports[`ColorTranslator blending tests Blending with L*a*b colors 8`] = `
+[
+  {
+    "A": 1,
+    "L": 54.291734,
+    "a": 80.812455,
+    "b": 69.88504,
+  },
+  {
+    "A": 1,
+    "L": 29.563244,
+    "a": 55.959822,
+    "b": -36.18907,
+  },
+  {
+    "A": 1,
+    "L": 29.567573,
+    "a": 68.298653,
+    "b": -112.02943,
+  },
+]
+`;
+
 exports[`ColorTranslator blending tests Blending with decimals snapshots 1`] = `
 [
   "rgb(255 0 0)",

--- a/tests/__snapshots__/shades-tints.test.ts.snap
+++ b/tests/__snapshots__/shades-tints.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ColorTranslator shades and tints tests Shades snapshots with L*a*b functions from "lab(54.291734 80.812455 69.88504 / 1)" 1`] = `
+exports[`ColorTranslator shades and tints tests Shades snapshots with L*a*b functions from "lab(54.2917337686 80.812455318 69.8850403235 / 1)" 1`] = `
 [
   "lab(45 70 61 / 1)",
   "lab(36 60 51 / 1)",
@@ -10,7 +10,7 @@ exports[`ColorTranslator shades and tints tests Shades snapshots with L*a*b func
 ]
 `;
 
-exports[`ColorTranslator shades and tints tests Shades snapshots with L*a*b functions from "lab(54.291734 80.812455 69.88504)" 1`] = `
+exports[`ColorTranslator shades and tints tests Shades snapshots with L*a*b functions from "lab(54.2917337686 80.812455318 69.8850403235)" 1`] = `
 [
   "lab(45 70 61)",
   "lab(36 60 51)",
@@ -255,7 +255,7 @@ exports[`ColorTranslator shades and tints tests Shades tests from {"R":255,"G":0
 ]
 `;
 
-exports[`ColorTranslator shades and tints tests Tints snapshots with L*a*b functions from "lab(54.291734 80.812455 69.88504 / 1)" 1`] = `
+exports[`ColorTranslator shades and tints tests Tints snapshots with L*a*b functions from "lab(54.2917337686 80.812455318 69.8850403235 / 1)" 1`] = `
 [
   "lab(56 76 56 / 1)",
   "lab(61 65 38 / 1)",
@@ -265,7 +265,7 @@ exports[`ColorTranslator shades and tints tests Tints snapshots with L*a*b funct
 ]
 `;
 
-exports[`ColorTranslator shades and tints tests Tints snapshots with L*a*b functions from "lab(54.291734 80.812455 69.88504)" 1`] = `
+exports[`ColorTranslator shades and tints tests Tints snapshots with L*a*b functions from "lab(54.2917337686 80.812455318 69.8850403235)" 1`] = `
 [
   "lab(56 76 56)",
   "lab(61 65 38)",

--- a/tests/blending.test.ts
+++ b/tests/blending.test.ts
@@ -57,6 +57,26 @@ describe('ColorTranslator blending tests', (): void => {
             expect(obj.blendFn(from, to, r2.length, options)).toMatchObject(r2);
 
             expect(obj.blendFn(from, to).length).toBe(5);
+            expect(
+                obj.blendFn(from, to, { decimals: 6 })
+            ).toMatchObject(
+                obj.blendFn(from, to)
+            );
+            expect(
+                obj.blendFn(from, to, 4, { decimals: 6 })
+            ).toMatchObject(
+                obj.blendFn(from, to, 4)
+            );
+            expect(
+                obj.blendFn(from, to, { cmykUnit: 'percent' })
+            ).toMatchObject(
+                obj.blendFn(from, to)
+            );
+            expect(
+                obj.blendFn(from, to, 3, { cmykUnit: 'percent' })
+            ).toMatchObject(
+                obj.blendFn(from, to, 3)
+            );
 
         });
 
@@ -75,6 +95,10 @@ describe('ColorTranslator blending tests', (): void => {
     it('Blending with L*a*b colors', (): void => {
         blendLabFunctions.forEach((fn) => {
             expect(fn(from, to)).toMatchSnapshot();
+        });
+
+        blendLabFunctions.forEach((fn) => {
+            expect(fn(from, to, 3)).toMatchSnapshot();
         });
     });
 

--- a/tests/color-mixing.test.ts
+++ b/tests/color-mixing.test.ts
@@ -117,6 +117,11 @@ describe('Color mixing with L*a*b colors', (): void => {
     });
     it('Return a mix in lab color with decimals', (): void => {
         expect(
+            ColorTranslator.getMixCIELab(['#F00', '#00F'], Mix.ADDITIVE)
+        ).toBe(
+            'lab(60.169696 93.550025 -60.498556)'
+        );
+        expect(
             ColorTranslator.getMixCIELab(['#F00', '#00F'])
         ).toBe(
             'lab(60.169696 93.550025 -60.498556)'

--- a/tests/harmony.test.ts
+++ b/tests/harmony.test.ts
@@ -131,4 +131,36 @@ describe('ColorTranslator harmony tests', (): void => {
         });
     });
 
+    it('Harmony excluding optional parameters', (): void => {
+        expect(
+            ColorTranslator.getHarmony(base, Harmony.COMPLEMENTARY, Mix.ADDITIVE)
+        ).toMatchObject(
+            ColorTranslator.getHarmony(base, Harmony.COMPLEMENTARY)
+        );
+
+        expect(
+            ColorTranslator.getHarmony(base, Harmony.COMPLEMENTARY, Mix.ADDITIVE)
+        ).toMatchObject(
+            ColorTranslator.getHarmony(base)
+        );
+
+        expect(
+            ColorTranslator.getHarmony(base, Harmony.COMPLEMENTARY, { decimals: 0 })
+        ).toMatchObject(
+            ColorTranslator.getHarmony(base, { decimals: 0 })
+        );
+
+        expect(
+            ColorTranslator.getHarmony(base, Mix.ADDITIVE)
+        ).toMatchObject(
+            ColorTranslator.getHarmony(base)
+        );
+
+        expect(
+            ColorTranslator.getHarmony(base, Mix.ADDITIVE, { decimals: 0 })
+        ).toMatchObject(
+            ColorTranslator.getHarmony(base, { decimals: 0 })
+        );
+    });
+
 });

--- a/tests/shades-tints.test.ts
+++ b/tests/shades-tints.test.ts
@@ -41,6 +41,11 @@ describe('ColorTranslator shades and tints tests', (): void => {
             const shades = ColorTranslator.getShades(input, 5);
             expect(shades).toMatchObject(output);
         });
+        it(`Shades tests without number of shades is equal to 5 from ${JSON.stringify(input)}`, (): void => {
+            const shades = ColorTranslator.getShades(input, 5);
+            const shadesDefault = ColorTranslator.getShades(input);
+            expect(shades).toMatchObject(shadesDefault);
+        });
         it(`Shades tests with alpha from ${JSON.stringify(inputWithAlpha)}`, (): void => {
             const output = shades_results.map((color: string) => fn(color + alpha));
             const shades = ColorTranslator.getShades(inputWithAlpha, 5);
@@ -48,13 +53,18 @@ describe('ColorTranslator shades and tints tests', (): void => {
         });
         it(`Tints tests from ${JSON.stringify(input)}`, (): void => {
             const output = tints_results.map((color: string) => fn(color));
-            const shades = ColorTranslator.getTints(input, 5);
-            expect(shades).toMatchObject(output);
+            const tints = ColorTranslator.getTints(input, 5);
+            expect(tints).toMatchObject(output);
+        });
+        it(`Tints tests without number of tints from ${JSON.stringify(input)}`, (): void => {
+            const tints = ColorTranslator.getTints(input, 5);
+            const tintsDefault = ColorTranslator.getTints(input);
+            expect(tints).toMatchObject(tintsDefault);
         });
         it(`Tints tests with alpha from ${JSON.stringify(inputWithAlpha)}`, (): void => {
             const output = tints_results.map((color: string) => fn(color + alpha));
-            const shades = ColorTranslator.getTints(inputWithAlpha, 5);
-            expect(shades).toMatchObject(output);
+            const tints = ColorTranslator.getTints(inputWithAlpha, 5);
+            expect(tints).toMatchObject(output);
         });
     });
 
@@ -75,13 +85,13 @@ describe('ColorTranslator shades and tints tests', (): void => {
         });
         it(`Tints tests from ${JSON.stringify(input)}`, (): void => {
             const output = tints_results.map((color: string) => fn(color, options));
-            const shades = ColorTranslator.getTints(input, 5, options);
-            expect(shades).toMatchObject(output);
+            const tints = ColorTranslator.getTints(input, 5, options);
+            expect(tints).toMatchObject(output);
         });
         it(`Tints tests with alpha from ${JSON.stringify(inputWithAlpha)}`, (): void => {
             const output = tints_results.map((color: string) => fn(color + alpha, options));
-            const shades = ColorTranslator.getTints(inputWithAlpha, 5, options);
-            expect(shades).toMatchObject(output);
+            const tints = ColorTranslator.getTints(inputWithAlpha, 5, options);
+            expect(tints).toMatchObject(output);
         });
         it(`Shades tests from ${JSON.stringify(input)} with decimals`, (): void => {
             const shades = ColorTranslator.getShades(input, 5, options);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "module": "esnext",
-    "target": "es5",
-    "lib": ["ES2017"],
+    "target": "ES2020",
+    "lib": ["ES2020"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
This pull request improves the `TypeScript` support and the flexibility of the API adding more methods overloads and allowing to accept also strings in the enum parameters. Also some bugs have been fixed.

The next changes are the main changes that have been applied:

### 1. For methods that use `Mix` and `Harmony` enums, now it is possible to send also string values.

### 2. Make optional the `shades` and `tints` parameters of the `getShades` and `getTints` methods respectively (the default will be `5`)

### 3. `getBlendStatic` methods now have two overloads

```typescript
getBlendColorsStaticMethod(
  fromColor: string | object,
  toColor: string | object,
  options?: Options
)

// Specifying the number of steps
getBlendColorsStaticMethod(
  fromColor: string | object,
  toColor: string | object,
  steps: number,
  options?: Options
)
```

### 4. `getMixStatic` methods now have two overloads

```typescript
getMixColorsStaticMethod(
  colors: [string | object][],
  options?: Options
)

// Specifying the mix mode
getMixColorsStaticMethod(
  colors: [string | object][],
  mode: 'ADDITIVE' | 'SUBTRACTIVE',
  options?: Options
)
```

### 5. `getHarmony` method now have four overloads for each color input

```typescript
// If harmony is not sent, the default will be "COMPLEMENTARY"
// If mode is not sent, the default will be "ADDITIVE"
getHarmony(
  color: string | object,
  options?: Options
)

// If mode is not sent, the default will be "ADDITIVE"
getHarmony(
  color: string | object,
  harmony: 'ANALOGOUS' | 'COMPLEMENTARY' | 'SPLIT_COMPLEMENTARY' | 'TRIADIC' | 'TETRADIC' | 'SQUARE',
  options?: Options
)

// If harmony is not sent, the default will be "COMPLEMENTARY"
getHarmony(
  color: string | object,
  mode: 'ADDITIVE' | 'SUBTRACTIVE',
  options?: Options
)

getHarmony(
  color: string | object,
  harmony: 'ANALOGOUS' | 'COMPLEMENTARY' | 'SPLIT_COMPLEMENTARY' | 'TRIADIC' | 'TETRADIC' | 'SQUARE',
  mode: 'ADDITIVE' | 'SUBTRACTIVE',
  options?: Options
)
```