### PR TITLE
Move color-strings parser logic to separate classes

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -205,3 +205,7 @@ export type InputOptions = Partial<
     alphaUnit?: `${ColorUnitEnum}`;
     cmykFunction?: `${CMYKFunctionEnum}`
 };
+
+export type MatchOptions = {
+    [K in keyof Pick<Options, 'legacyCSS' | 'spacesAfterCommas' | 'cmykFunction'>]: number;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ import {
 import * as utils from '#color/utils';
 import { CSS } from '#color/css';
 import {
-    getOptionsFromColorInput,
     isHarmony,
     isMix,
     minmax,
@@ -87,7 +86,7 @@ export class ColorTranslator {
 
     // Constructor
     public constructor(color: ColorInput, options: InputOptions = {}) {
-        this._options = getOptionsFromColorInput(options, color);
+        this._options = utils.getOptionsFromColorInput(options, color);
         this.rgb = utils.getRGBObject(color);
         this.updateHSL();
         this.updateLab();
@@ -580,7 +579,7 @@ export class ColorTranslator {
 
     public static toRGB(color: ColorInput, options: InputOptions = {}): string {
         const model = utils.getColorModel(color);
-        const detectedOptions = getOptionsFromColorInput(options, color);
+        const detectedOptions = utils.getOptionsFromColorInput(options, color);
         const rgb = getColorReturn<RGBObject>(
             color,
             model,
@@ -602,7 +601,7 @@ export class ColorTranslator {
 
     public static toRGBA(color: ColorInput, options: InputOptions = {}): string {
         const model = utils.getColorModel(color);
-        const detectedOptions = getOptionsFromColorInput(options, color);
+        const detectedOptions = utils.getOptionsFromColorInput(options, color);
         const rgba = getColorReturn<RGBObject>(
             color,
             model,
@@ -624,7 +623,7 @@ export class ColorTranslator {
 
     public static toHSL(color: ColorInput, options: InputOptions = {}): string {
         const model = utils.getColorModel(color);
-        const detectedOptions = getOptionsFromColorInput(options, color);
+        const detectedOptions = utils.getOptionsFromColorInput(options, color);
         const hsl = getColorReturn<HSLObject>(
             color,
             model,
@@ -646,7 +645,7 @@ export class ColorTranslator {
 
     public static toHSLA(color: ColorInput, options: InputOptions = {}): string {
         const model = utils.getColorModel(color);
-        const detectedOptions = getOptionsFromColorInput(options, color);
+        const detectedOptions = utils.getOptionsFromColorInput(options, color);
         const hsla = getColorReturn<HSLObject>(
             color,
             model,
@@ -668,7 +667,7 @@ export class ColorTranslator {
 
     public static toCIELab(color: ColorInput, options: InputOptions = {}): string {
         const model = utils.getColorModel(color);
-        const detectedOptions = getOptionsFromColorInput(options, color);
+        const detectedOptions = utils.getOptionsFromColorInput(options, color);
         const lab = getColorReturn<CIELabObject>(
             color,
             model,
@@ -690,7 +689,7 @@ export class ColorTranslator {
 
     public static toCIELabA(color: ColorInput, options: InputOptions = {}): string {
         const model = utils.getColorModel(color);
-        const detectedOptions = getOptionsFromColorInput(options, color);
+        const detectedOptions = utils.getOptionsFromColorInput(options, color);
         const lab = getColorReturn<CIELabObject>(
             color,
             model,
@@ -712,7 +711,7 @@ export class ColorTranslator {
 
     public static toCMYK(color: ColorInput, options: InputOptions = {}): string {
         const model = utils.getColorModel(color);
-        const detectedOptions = getOptionsFromColorInput(options, color);
+        const detectedOptions = utils.getOptionsFromColorInput(options, color);
         const cmyk = getColorReturn<CMYKObject>(
             color,
             model,
@@ -734,7 +733,7 @@ export class ColorTranslator {
 
     public static toCMYKA(color: ColorInput, options: InputOptions = {}): string {
         const model = utils.getColorModel(color);
-        const detectedOptions = getOptionsFromColorInput(options, color);
+        const detectedOptions = utils.getOptionsFromColorInput(options, color);
         const cmyka = getColorReturn<CMYKObject>(
             color,
             model,
@@ -854,7 +853,7 @@ export class ColorTranslator {
                 .map((color: RGBObject): string => {
                     return CSS.RGB(
                         color,
-                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                        utils.getOptionsFromColorInput(fourthParameter || {}, from, to)
                     );
                 });
         }
@@ -868,7 +867,7 @@ export class ColorTranslator {
             .map((color: RGBObject): string => {
                 return CSS.RGB(
                     color,
-                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                    utils.getOptionsFromColorInput(thirdParameter || {}, from, to)
                 );
             });
     }
@@ -936,7 +935,7 @@ export class ColorTranslator {
                 .map((color: RGBObject): string => {
                     return CSS.RGB(
                         color,
-                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                        utils.getOptionsFromColorInput(fourthParameter || {}, from, to)
                     );
                 });
         }
@@ -950,7 +949,7 @@ export class ColorTranslator {
             .map((color: RGBObject): string => {
                 return CSS.RGB(
                     color,
-                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                    utils.getOptionsFromColorInput(thirdParameter || {}, from, to)
                 );
             });
     }
@@ -1018,7 +1017,7 @@ export class ColorTranslator {
                 .map((color: HSLObject) => {
                     return CSS.HSL(
                         color,
-                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                        utils.getOptionsFromColorInput(fourthParameter || {}, from, to)
                     );
                 });
         }
@@ -1032,7 +1031,7 @@ export class ColorTranslator {
             .map((color: HSLObject) => {
                 return CSS.HSL(
                     color,
-                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                    utils.getOptionsFromColorInput(thirdParameter || {}, from, to)
                 );
             });
     }
@@ -1100,7 +1099,7 @@ export class ColorTranslator {
                 .map((color: HSLObject): string => {
                     return CSS.HSL(
                         color,
-                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                        utils.getOptionsFromColorInput(fourthParameter || {}, from, to)
                     );
                 });
         }
@@ -1114,7 +1113,7 @@ export class ColorTranslator {
             .map((color: HSLObject): string => {
                 return CSS.HSL(
                     color,
-                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                    utils.getOptionsFromColorInput(thirdParameter || {}, from, to)
                 );
             });
     }
@@ -1182,7 +1181,7 @@ export class ColorTranslator {
                 .map((color: CIELabObject) => {
                     return CSS.CIELab(
                         color,
-                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                        utils.getOptionsFromColorInput(fourthParameter || {}, from, to)
                     );
                 });
         }
@@ -1196,7 +1195,7 @@ export class ColorTranslator {
             .map((color: CIELabObject) => {
                 return CSS.CIELab(
                     color,
-                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                    utils.getOptionsFromColorInput(thirdParameter || {}, from, to)
                 );
             });
     }
@@ -1264,7 +1263,7 @@ export class ColorTranslator {
                 .map((color: CIELabObject) => {
                     return CSS.CIELab(
                         color,
-                        getOptionsFromColorInput(fourthParameter || {}, from, to)
+                        utils.getOptionsFromColorInput(fourthParameter || {}, from, to)
                     );
                 });
         }
@@ -1278,7 +1277,7 @@ export class ColorTranslator {
             .map((color: CIELabObject) => {
                 return CSS.CIELab(
                     color,
-                    getOptionsFromColorInput(thirdParameter || {}, from, to)
+                    utils.getOptionsFromColorInput(thirdParameter || {}, from, to)
                 );
             });
     }
@@ -1319,7 +1318,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 false,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1329,7 +1328,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1355,7 +1354,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 true,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1365,7 +1364,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1391,7 +1390,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 false,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1401,7 +1400,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1427,7 +1426,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 true,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1437,7 +1436,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1463,7 +1462,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 false,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1473,7 +1472,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1499,7 +1498,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 true,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1509,7 +1508,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1535,7 +1534,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 false,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1545,7 +1544,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1571,7 +1570,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 true,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1581,7 +1580,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1607,7 +1606,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 false,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1617,7 +1616,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1643,7 +1642,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 true,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1653,7 +1652,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1679,7 +1678,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 false,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1689,7 +1688,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             false,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1715,7 +1714,7 @@ export class ColorTranslator {
                 colors,
                 secondParameter,
                 true,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     ...colors
                 )
@@ -1725,7 +1724,7 @@ export class ColorTranslator {
             colors,
             Mix.ADDITIVE,
             true,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 ...colors
             )
@@ -1755,7 +1754,7 @@ export class ColorTranslator {
                 color,
                 secondParameter,
                 true,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     color
                 )
@@ -1765,7 +1764,7 @@ export class ColorTranslator {
             color,
             DEFAULT_SHADES_TINTS_STEPS,
             true,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 color
             )
@@ -1795,7 +1794,7 @@ export class ColorTranslator {
                 color,
                 secondParameter,
                 false,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParameter || {},
                     color
                 )
@@ -1805,7 +1804,7 @@ export class ColorTranslator {
             color,
             DEFAULT_SHADES_TINTS_STEPS,
             false,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParameter || {},
                 color
             )
@@ -1850,7 +1849,7 @@ export class ColorTranslator {
                 isMix(thirdParam)
                     ? thirdParam
                     : Mix.ADDITIVE,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     isMix(thirdParam)
                         ? (fourthParam || {})
                         : thirdParam || {},
@@ -1862,7 +1861,7 @@ export class ColorTranslator {
                 Harmony.COMPLEMENTARY,
                 color,
                 secondParam,
-                getOptionsFromColorInput(
+                utils.getOptionsFromColorInput(
                     thirdParam as InputOptions || {},
                     color
                 )
@@ -1872,7 +1871,7 @@ export class ColorTranslator {
             Harmony.COMPLEMENTARY,
             color,
             Mix.ADDITIVE,
-            getOptionsFromColorInput(
+            utils.getOptionsFromColorInput(
                 secondParam || {},
                 color
             )

--- a/src/parsers/_CIELabStringParser.ts
+++ b/src/parsers/_CIELabStringParser.ts
@@ -1,0 +1,56 @@
+import { CIELabRegExpMatchArray, RGBObject } from '@types';
+import { COLORREGS, PCENT } from '#constants';
+import {
+    getBase125Number,
+    normalizeAlpha,
+    percent
+} from '#helpers';
+import { labToRgb } from '#color/translators';
+
+export class CIELabStringParser {
+
+    constructor(colorString: string) {
+        const match = colorString.match(COLORREGS.CIELab) as CIELabRegExpMatchArray;
+        const groups = match.groups;
+        this._L = groups.L;
+        this._a = groups.a;
+        this._b = groups.b;
+        this._A = groups.A;
+        const rgb: RGBObject = labToRgb(
+            percent(this._L),
+            getBase125Number(this._a),
+            getBase125Number(this._b)
+        );
+        if (this._A !== undefined) {
+            rgb.A = normalizeAlpha(this._A);
+        }
+        this._rgb = rgb;
+    }
+
+    private _L: string;
+    private _a: string;
+    private _b: string;
+    private _A: string | undefined;
+    private _rgb: RGBObject;
+
+    public get rgb(): RGBObject {
+        return this._rgb;
+    }
+
+    public get hasPercentageValues(): boolean {
+        return (
+            PCENT.test(this._L) &&
+            PCENT.test(this._a) &&
+            PCENT.test(this._b)
+        );
+    }
+
+    public get hasPercentageAlpha(): boolean {
+        return PCENT.test(this._A);
+    }
+
+    static test(colorString: string): boolean {
+        return COLORREGS.CIELab.test(colorString);
+    }
+
+}

--- a/src/parsers/_CMYKStringParser.ts
+++ b/src/parsers/_CMYKStringParser.ts
@@ -1,0 +1,57 @@
+import { CMYKRegExpMatchArray, RGBObject } from '@types';
+import { COLORREGS, PCENT } from '#constants';
+import { getCMYKNumber, normalizeAlpha } from '#helpers';
+import { cmykToRGB } from '#color/translators';
+
+export class CMYKStringParser {
+
+    constructor(colorString: string) {
+        const match = colorString.match(COLORREGS.CMYK) as CMYKRegExpMatchArray;
+        const groups = match.groups;
+        this._c = groups.c_legacy ?? groups.c;
+        this._m = groups.m_legacy ?? groups.m;
+        this._y = groups.y_legacy ?? groups.y;
+        this._k = groups.k_legacy ?? groups.k;
+        this._a = groups.a_legacy ?? groups.a;
+        const rgb: RGBObject = cmykToRGB(
+            getCMYKNumber(this._c),
+            getCMYKNumber(this._m),
+            getCMYKNumber(this._y),
+            getCMYKNumber(this._k)
+        );
+        if (this._a !== undefined) {
+            rgb.A = normalizeAlpha(this._a);
+        }
+        this._rgb = rgb;
+    }
+
+    private _c: string;
+    private _m: string;
+    private _y: string;
+    private _k: string;
+    private _a: string | undefined;
+
+    private _rgb: RGBObject;
+
+    public get rgb(): RGBObject {
+        return this._rgb;
+    }
+
+    public get hasPercentageValues(): boolean {
+        return (
+            PCENT.test(this._c) &&
+            PCENT.test(this._m) &&
+            PCENT.test(this._y) &&
+            PCENT.test(this._k)
+        );
+    }
+
+    public get hasPercentageAlpha(): boolean {
+        return PCENT.test(this._a);
+    }
+
+    static test(colorString: string): boolean {
+        return COLORREGS.CMYK.test(colorString);
+    }
+
+}

--- a/src/parsers/_HEXStringParser.ts
+++ b/src/parsers/_HEXStringParser.ts
@@ -1,0 +1,35 @@
+import { RGBObject, HEXRegExpMatchArray } from '@types';
+import { COLORREGS } from '#constants';
+import { getDEC } from '#helpers';
+
+export class HEXStringParser {
+
+    constructor(colorString: string) {
+        const match = colorString.match(COLORREGS.HEX) as HEXRegExpMatchArray;
+        const groups = match.groups;
+        this._r = groups.r ?? groups.rr;
+        this._g = groups.g ?? groups.gg;
+        this._b = groups.b ?? groups.bb;
+        this._a = groups.a ?? groups.aa;
+        const rgb: RGBObject = {
+            R: getDEC(this._r),
+            G: getDEC(this._g),
+            B: getDEC(this._b)
+        };
+        if (this._a !== undefined) {
+            rgb.A = getDEC(this._a) / 255;
+        }
+        this._rgb = rgb;
+    }
+
+    private _r: string;
+    private _g: string;
+    private _b: string;
+    private _a: string | undefined;
+    private _rgb: RGBObject;
+
+    public get rgb(): RGBObject {
+        return this._rgb;
+    }
+
+}

--- a/src/parsers/_HSLStringParser.ts
+++ b/src/parsers/_HSLStringParser.ts
@@ -1,0 +1,65 @@
+import {
+    AnglesUnitEnum,
+    AngleUnitRegExpMatchArray,
+    HSLRegExpMatchArray,
+    RGBObject
+} from '@types';
+import {
+    COLORREGS,
+    HSL_HUE,
+    PCENT
+} from '#constants';
+import {
+    normalizeAlpha,
+    normalizeHue,
+    percent
+} from '#helpers';
+import { hslToRGB } from '#color/translators';
+
+export class HSLStringParser {
+
+    constructor(colorString: string) {
+        const match = colorString.match(COLORREGS.HSL) as HSLRegExpMatchArray;
+        const groups = match.groups;
+        this._h = groups.h_legacy ?? groups.h;
+        this._s = groups.s_legacy ?? groups.s;
+        this._l = groups.l_legacy ?? groups.l;
+        this._a = groups.a_legacy ?? groups.a;
+        const rgb: RGBObject = hslToRGB(
+            normalizeHue(this._h),
+            percent(this._s),
+            percent(this._l)
+        );
+        if (this._a !== undefined) {
+            rgb.A = normalizeAlpha(this._a);
+        }
+        this._rgb = rgb;
+    }
+
+    private _h: string;
+    private _s: string;
+    private _l: string;
+    private _a: string | undefined;
+    private _rgb: RGBObject;
+
+    public get rgb(): RGBObject {
+        return this._rgb;
+    }
+
+    public get angleUnit(): AnglesUnitEnum {
+        const angleUnitMatch = this._h.match(HSL_HUE) as AngleUnitRegExpMatchArray;
+        const angleUnit = angleUnitMatch.groups.units;
+        return angleUnit === ''
+            ? AnglesUnitEnum.NONE
+            : angleUnit as AnglesUnitEnum;
+    }
+
+    public get hasPercentageAlpha(): boolean {
+        return PCENT.test(this._a);
+    }
+
+    static test(colorString: string): boolean {
+        return COLORREGS.HSL.test(colorString);
+    }
+
+}

--- a/src/parsers/_RGBStringParser.ts
+++ b/src/parsers/_RGBStringParser.ts
@@ -1,0 +1,61 @@
+import { RGBObject, RGBRegExpMatchArray } from '@types';
+import { COLORREGS, PCENT } from '#constants';
+import { getBase255Number, normalizeAlpha } from '#helpers';
+
+export class RGBStringParser {
+
+    constructor(colorString: string) {
+        const BASE = 255;
+        const match = colorString.match(COLORREGS.RGB) as RGBRegExpMatchArray;
+        const groups = match.groups;
+        this._r = groups.r_legacy ?? groups.r;
+        this._g = groups.g_legacy ?? groups.g;
+        this._b = groups.b_legacy ?? groups.b;
+        this._a = groups.a_legacy ?? groups.a;
+        const rgb: RGBObject = {
+            R: Math.min(
+                getBase255Number(this._r),
+                BASE
+            ),
+            G: Math.min(
+                getBase255Number(this._g),
+                BASE
+            ),
+            B: Math.min(
+                getBase255Number(this._b),
+                BASE
+            )
+        };
+        if (this._a !== undefined) {
+            rgb.A = normalizeAlpha(this._a);
+        }
+        this._rgb = rgb;
+    }
+
+    private _r: string;
+    private _g: string;
+    private _b: string;
+    private _a: string | undefined;
+    private _rgb: RGBObject;
+
+    public get rgb(): RGBObject {
+        return this._rgb;
+    }
+
+    public get hasPercentageValues(): boolean {
+        return (
+            PCENT.test(this._r) &&
+            PCENT.test(this._g) &&
+            PCENT.test(this._b)
+        );
+    }
+
+    public get hasPercentageAlpha(): boolean {
+        return PCENT.test(this._a);
+    }
+
+    static test(colorString: string): boolean {
+        return COLORREGS.RGB.test(colorString);
+    }
+
+}

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,0 +1,5 @@
+export { HEXStringParser } from './_HEXStringParser';
+export { RGBStringParser } from './_RGBStringParser';
+export { HSLStringParser } from './_HSLStringParser';
+export { CIELabStringParser } from './_CIELabStringParser';
+export { CMYKStringParser } from './_CMYKStringParser';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
       "@types": ["@types"],
       "#helpers": ["helpers"],
       "#constants": ["constants"],
-      "#color/*": ["color/*"]
+      "#color/*": ["color/*"],
+      "#parsers": ["parsers"]
     }
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
This pull request refactors the code to move color-strings parser logic to separate classes, and in this way, abstract the logic of parsing the strings to colours to separate color-model specific modules.